### PR TITLE
Allow dockerfile to build

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 # Written by Ange Cesari
 # Use official Node.js based on Alpine
-FROM node:16-alpine
+FROM node:18-alpine
 
 # Install Yarn
 RUN apk add --no-cache yarn


### PR DESCRIPTION
The current dependency jsdom@23.2.0 requires node >=18. Tested build and runtime.