### PR TITLE
Fix for #35

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 # Written by Ange Cesari
 # Use official Node.js based on Alpine
-FROM node:18-alpine
+FROM node:20-alpine
 
 # Install Yarn
 RUN apk add --no-cache yarn


### PR DESCRIPTION
Fix for this issue https://github.com/igorski/bitmappery/issues/35.

App installs module pdfjs-dist@4.9.155 that requires at least node 20, but docker pulls image with node 18. It appears this can be easily fixed by bumping node image to version 20 in dockerfile.

This has solved the issue for me.