### PR TITLE
Declutter paint routines and fill mode bugs

### DIFF
--- a/src/components/stroke-selection-window/stroke-selection-window.vue
+++ b/src/components/stroke-selection-window/stroke-selection-window.vue
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Igor Zinken 2022 - https://www.igorski.nl
+ * Igor Zinken 2022-2025 - https://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -65,7 +65,7 @@
     </modal>
 </template>
 
-<script>
+<script lang="ts">
 import { mapGetters, mapMutations } from "vuex";
 import ColorPicker from "@/components/ui/color-picker/color-picker.vue";
 import Modal from "@/components/modal/modal.vue";
@@ -90,25 +90,25 @@ export default {
             "activeLayer",
             "activeColor",
         ]),
-        isValid() {
+        isValid(): boolean {
             return this.size > 0 && this.color;
         },
     },
-    created() {
+    created(): void {
         this.color = this.activeColor;
     },
-    mounted() {
+    mounted(): void {
         focus( this.$refs.sizeInput );
     },
     methods: {
         ...mapMutations([
             "closeModal",
         ]),
-        stroke() {
+        stroke(): void {
             if ( !this.isValid ) {
                 return;
             }
-            getSpriteForLayer( this.activeLayer ).paint({
+            getSpriteForLayer( this.activeLayer )?.paint({
                 type      : "stroke",
                 size      : this.size,
                 color     : this.color,
@@ -131,7 +131,7 @@ export default {
 .color-picker {
     width: 50%;
     display: inline-block;
-    transform: translateY(-(variables.$spacing-xsmall));
+    transform: translateY(variables.$spacing-xxsmall);
 }
 
 .size-input {

--- a/src/math/selection-math.ts
+++ b/src/math/selection-math.ts
@@ -37,10 +37,10 @@ const RIGHT  = 3;
 export const selectByColor = ( cvs: HTMLCanvasElement, sourceX: number, sourceY: number, threshold = 0 ): Shape => {
     const { width, height } = cvs;
 
-    const ctx = cvs.getContext( "2d" );
+    const ctx = cvs.getContext( "2d" ) as CanvasRenderingContext2D;
 
-    sourceX = Math.min( width  - 1, Math.round( sourceX ));
-    sourceY = Math.min( height - 1, Math.round( sourceY ));
+    sourceX = Math.max( 0, Math.min( width  - 1, Math.round( sourceX )));
+    sourceY = Math.max( 0, Math.min( height - 1, Math.round( sourceY )));
 
     // the source color
     const [ r, g, b, a ] = ctx.getImageData( sourceX, sourceY, 1, 1 ).data;

--- a/src/rendering/canvas-elements/layer-sprite.ts
+++ b/src/rendering/canvas-elements/layer-sprite.ts
@@ -314,8 +314,8 @@ class LayerSprite extends ZoomableSprite {
         const pointers = isDrawing ? sliceBrushPointers( this._brush ) : undefined;
         const transformedPointers = createOverrideConfig( this.canvas, pointers );
         
-        // smart fill mode operates directly on source, all other drawing operations on a temporary Canvas
-        const usePaintCanvas = this.usePaintCanvas();
+        // most drawing operations operate directly onto a temporary Canvas
+        const usePaintCanvas = this.usePaintCanvas() || ( optAction?.type === "stroke" );
         const doSaveRestore  = !!selection; // selections will apply context clipping which needs to be restored
 
         if ( doSaveRestore ) {
@@ -337,11 +337,11 @@ class LayerSprite extends ZoomableSprite {
 
         if ( optAction ) {
             if ( optAction.type === "stroke" ) {
-                console.info('is stroke. use paint canvas? (it SHOULD) : ',usePaintCanvas)
                 ctx.strokeStyle = optAction.color;
                 ctx.lineWidth   = ( optAction.size ?? 1 ) / this.canvas.documentScale;
                 ctx.stroke();
             }
+            this.handleRelease( 0, 0 ); // supplied outside actions are instantly completed actions
         } else if ( isFillMode ) {
             const color = this.getStore().getters.activeColor;
    
@@ -605,10 +605,10 @@ class LayerSprite extends ZoomableSprite {
             );
             disposeDrawableCanvas();
             this.resetFilterAndRecache();
-            
+
             this._paintCanvas = null;
-            this._brush.down = false;
-            this._brush.last = 0;
+            this._brush.down  = false;
+            this._brush.last  = 0;
             this._brush.pointers.length = 0;
 
             // immediately store pending history state when not running in lowMemory mode

--- a/src/rendering/canvas-elements/layer-sprite.ts
+++ b/src/rendering/canvas-elements/layer-sprite.ts
@@ -436,15 +436,16 @@ class LayerSprite extends ZoomableSprite {
         }
         this._pendingPaintState = undefined;
 
-        const layer    = this.layer;
         const orgBlob  = await canvasToBlob( this._orgSourceToStore );
         const orgState = blobToResource( orgBlob );
-
+        const newBlob  = await canvasToBlob( this.getPaintSource() );
+        const newState = blobToResource( newBlob );
+        
         this._orgSourceToStore = undefined;
 
+        const layer  = this.layer;
         const isMask = this.isMaskable();
-        const blob   = await canvasToBlob( this.getPaintSource() );
-        const newState = blobToResource( blob );
+
         enqueueState( `spritePaint_${layer.id}`, {
             undo(): void {
                 restorePaintFromHistory( layer, orgState, isMask );

--- a/src/rendering/canvas-elements/layer-sprite.ts
+++ b/src/rendering/canvas-elements/layer-sprite.ts
@@ -435,14 +435,13 @@ class LayerSprite extends ZoomableSprite {
         this._pendingPaintState = undefined;
 
         const original = this._orgSourceToStore; // grab reference to avoid race conditions while creating Blobs during continued painting
+        this._orgSourceToStore = undefined;
 
         const newBlob  = await canvasToBlob( this.getPaintSource() );
         const newState = blobToResource( newBlob );
         const orgBlob  = await canvasToBlob( original );
         const orgState = blobToResource( orgBlob );
         
-        this._orgSourceToStore = undefined;
-
         const layer  = this.layer;
         const isMask = this.isMaskable();
 

--- a/src/rendering/canvas-elements/layer-sprite.ts
+++ b/src/rendering/canvas-elements/layer-sprite.ts
@@ -318,20 +318,18 @@ class LayerSprite extends ZoomableSprite {
         const usePaintCanvas = this.usePaintCanvas() || ( optAction?.type === "stroke" );
         const doSaveRestore  = !!selection; // selections will apply context clipping which needs to be restored
 
-        if ( doSaveRestore ) {
-            ctx.save();
-        }
-
         if ( usePaintCanvas ) {
             // drawing is handled on a temporary, drawable Canvas
             this._paintCanvas = this._paintCanvas || getDrawableCanvas( this.getPaintSize() );
             ({ ctx } = this._paintCanvas );
 
             if ( selection ) {
+                ctx.save();
                 // note no offset is required when drawing on the full-size _paintCanvas
                 clipContextToSelection( ctx, selection, 0, 0, this._invertSelection, transformedPointers );
             }
         } else if ( selection ) {
+            ctx.save();
             clipContextToSelection( ctx, selection, this.layer.left, this.layer.top, this._invertSelection );
         }
 
@@ -436,10 +434,12 @@ class LayerSprite extends ZoomableSprite {
         }
         this._pendingPaintState = undefined;
 
-        const orgBlob  = await canvasToBlob( this._orgSourceToStore );
-        const orgState = blobToResource( orgBlob );
+        const original = this._orgSourceToStore; // grab reference to avoid race conditions while creating Blobs during continued painting
+
         const newBlob  = await canvasToBlob( this.getPaintSource() );
         const newState = blobToResource( newBlob );
+        const orgBlob  = await canvasToBlob( original );
+        const orgState = blobToResource( orgBlob );
         
         this._orgSourceToStore = undefined;
 

--- a/src/rendering/fill.ts
+++ b/src/rendering/fill.ts
@@ -20,6 +20,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+import { type Point } from "zcanvas";
 import { selectByColor } from "@/math/selection-math";
 
 const TWO_PI = Math.PI * 2;
@@ -45,7 +46,8 @@ export const floodFill = ( ctx: CanvasRenderingContext2D, sourceX: number, sourc
     ctx.lineJoin    = "round";
     ctx.lineCap     = "round";
 
-    let point, nextPoint;
+    let point: Point;
+    let nextPoint: Point;
 
     if ( path.length < 3 ) {
         point = path[ 0 ];

--- a/src/rendering/utils/drawable-canvas-utils.ts
+++ b/src/rendering/utils/drawable-canvas-utils.ts
@@ -76,7 +76,7 @@ export const renderDrawableCanvas = (
         source,
         0, 0, source.width, source.height,
         (( viewport?.left ?? 0 ) * documentScale ) + ( offset?.x ?? 0 ),
-        (( viewport?.top ?? 0 )  * documentScale ) + ( offset?.y ?? 0 ),
+        (( viewport?.top  ?? 0 ) * documentScale ) + ( offset?.y ?? 0 ),
         destinationSize.width, destinationSize.height
     );
 


### PR DESCRIPTION
* Simplify temporary canvas setup in layer-sprite's `paint()` routine
* Ensure fill, clear and stroke operations work the same like brushed painting by using a temporary canvas and apply transformations at the end