### PR TITLE
Add support for unique state history per Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Please vote on feature requests by using the Thumbs Up/Down reaction on the firs
 
 ## Model
 
-BitMappery works with entities known as `Document`s. A Document contains several `Layer`s, each of
-which define their content, transformation, `Effect`s, etc. Each of the nested entity properties
+BitMappery works with entities known as a `Document`. A Document contains several `Layer`s, each of
+which define their content, transformation, `Filters`, etc. Each of the nested entity properties
 has its own factory (see `src/factories`). The Document is managed by the Vuex `document-module.ts`.
 
 The types for each of these are defined in `src/definitions/document.ts`.
@@ -45,7 +45,7 @@ Interactions that start/end from _outside the canvas_ (for instance the opening/
 drawing of a brush stroke outside of the canvas area) are handled by `document-canvas.vue` where the global DOM coordinates are translated to coordinates relative to the canvas document before being forwarded to the zCanvas
 event handler. See "Rendering concepts" below for more details on screen-to-document coordinates.
 
-Rendering of transformations, text and effects is an asynchronous operation handled by `src/services/render-service.ts`. The purpose of this service is to perform and cache repeated operations and eventually maintain
+Rendering of transformations, text and filters is an asynchronous operation handled by `src/services/render-service.ts`. The purpose of this service is to perform and cache repeated operations and eventually maintain
 the source bitmap represented by the LayerRenderer. The LayerRenderer invokes the rendering service whenever
 Layer content changes and manages its own cache.
 
@@ -73,7 +73,8 @@ and translating these to (non-zoomed and non-panned) source bitmaps.
 Mutations can be registered in state history (Vuex `history-module.ts`) in order to provide undo and redo
 of operations. In order to prevent storing a lot of changes of the same property (for instance when dragging a slider), the storage of a new state is deferred through a queue. This is why history states are enqueued by _propertyName_:
 
-When enqueuing a new state while there is an existing one enqueued for the same property name, the first state is updated so its redo will match that of the newest state, the undo remaining unchanged. The second state will not
+When enqueuing a new state while there is an existing one enqueued for the same property name, the first state
+is updated so its redo will match that of the newest state, the undo remaining unchanged. The second state will not
 be added to the queue.
 
 It is good to understand that the undo/redo for an action should be considered separate
@@ -88,7 +89,9 @@ the application lifetime before the undo/redo handler fires which would otherwis
 being updated.
 
 ```typescript
-update( propertyName: string, newValue: any ): void {
+import { enqueueState } from "@/factories/history-state-factory";
+
+update( propertyName: string, newValue: T ): void {
     // cache the existing values of the property value we are about to mutate...
     const existingValue = this.getterForExistingValue;
     // ...and the layer index that is used to identify the layer containing the property
@@ -110,9 +113,14 @@ update( propertyName: string, newValue: any ): void {
 }
 ```
 
+### State changing actions
+
 Whenever an action (that requires an undo state) can be triggered in multiple locations (for instance
 inside a component and as a keyboard shortcut in `src/services/keyboard-service`), you can
 create a custom handler inside `src/store/actions` to avoid code duplication.
+
+Creating a custom handler also creates a single source of truth and an isolated piece of code
+that can be covered more easily in tests.
 
 ## Third party storage integration
 
@@ -168,8 +176,8 @@ BitMappery can also use WebAssembly to _potentially_ increase performance of ima
 WebAssembly filtering is a user controllable feature in the preferences pane, as long as the `.env` file has set
 support for `VITE_ENABLE_WASM_FILTERS` to true.
 
-The source code is C based and compiled to WASM using [Emscripten](https://github.com/emscripten-core/emscripten). Because this setup is a little more cumbersome, the repository contains precompiled binaries in the `src/wasm/bin`-folder meaning you can
-omit this setup if you don't intend to make changes to these sources.
+The source code is C based and compiled to WASM using [Emscripten](https://github.com/emscripten-core/emscripten). Because this setup is a little more cumbersome, the repository contains precompiled binaries in the `src/wasm/bin`-folder meaning
+you can omit this setup if you don't intend to make changes to these sources.
 
 If you do wish to make contributions on this end, to compile the source (`src/wasm`) C-code to WASM, you
 will first need to prepare your environment (note the last _source_ call does not permanently update your paths):
@@ -197,9 +205,9 @@ On a particular (deliberately low powered) configuration, running all filters at
 * 484 ms in JavaScript inside a Web Worker
 * 603 ms in WebAssembly inside a Web Worker
 
-Note that the WebAssembly Web Worker takes a performance hit from converting the ImageData buffer
-to float32 prior to allocating the buffer in the WASM instance's memory. This could benefit from
-further tweaking to see if it gets closer to the JavaScript Web Worker performance.
+Note that the WebAssembly Web Worker execution takes a performance hit when compared to its inline operation. This
+is due to messaging overhead when providing image buffers to the WASM memory. This could benefit from further tweaking
+to see whether it gets closer to the JavaScript Web Worker performance.
 
 However, as in the current setup the JS solution alone is performant enough _and you would need to write the
 filter code twice_ (once in TypeScript in `src/rendering/filters` and once in C++ in `src/wasm`), the default for WASM is disabled.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ On a particular (deliberately low powered) configuration, running all filters at
 * 603 ms in WebAssembly inside a Web Worker
 
 Note that the WebAssembly Web Worker execution takes a performance hit when compared to its inline operation. This
-is due to messaging overhead when providing image buffers to the WASM memory. This could benefit from further tweaking
+is due to messaging overhead when providing image buffers to the WASM memory inside the Worker context. This could benefit from further tweaking
 to see whether it gets closer to the JavaScript Web Worker performance.
 
 However, as in the current setup the JS solution alone is performant enough _and you would need to write the

--- a/src/bitmappery.vue
+++ b/src/bitmappery.vue
@@ -209,7 +209,6 @@ export default {
     watch: {
         activeDocument( activeDocument: Document ): void {
             if ( !activeDocument?.layers ) {
-                this.resetHistory();
                 if ( isMobile() ) {
                     this.closeOpenedPanels();
                 }
@@ -227,7 +226,7 @@ export default {
                     } else {
                         this.updateMeta({ smoothing: this.antiAlias });
                     }
-                    this.resetHistory();
+                    this.registerDocument( activeDocument );
                 }
             }
         },
@@ -313,7 +312,7 @@ export default {
             "closeModal",
             "closeOpenedPanels",
             "openDialog",
-            "resetHistory",
+            "registerDocument",
             "setToolboxOpened",
             "setToolOptionValue",
             "setLoading",

--- a/src/factories/history-state-factory.ts
+++ b/src/factories/history-state-factory.ts
@@ -29,9 +29,10 @@ import { type BitMapperyState } from "@/store";
  * Blob URLs will be revoked when the state is popped from the history stack to free memory.
  */
 export type UndoRedoState = {
-     undo: () => void;
-     redo: () => void;
-     resources?: string[];
+    id: string; // activeDocument id
+    undo: () => void;
+    redo: () => void;
+    resources?: string[];
 };
 
 const stateQueue      = new Map<string, UndoRedoState>();
@@ -63,11 +64,11 @@ export const forceProcess = processQueue;
  * @param {String} key unique identifier for this state
  * @param {UndoRedoState} undoRedoState
  */
-export const enqueueState = ( key: string, undoRedoState: UndoRedoState ): void => {
+export const enqueueState = ( key: string, undoRedoState: Omit<UndoRedoState, "id"> ): void => {
     // new state is for the same property as the previously enqueued state
     // we can discard the previously enqueued states.redo in favour of this more actual one
     if ( stateQueue.has( key )) {
-        const existing = stateQueue.get( key );
+        const existing = stateQueue.get( key )!;
         existing.redo = undoRedoState.redo;
         if ( existing.resources && undoRedoState.resources ) {
             existing.resources.push( ...undoRedoState.resources );
@@ -79,7 +80,10 @@ export const enqueueState = ( key: string, undoRedoState: UndoRedoState ): void 
     if ( hasQueue() ) {
         processQueue();
     }
-    stateQueue.set( key, undoRedoState );
+    const stateToSet = undoRedoState as UndoRedoState;
+    stateToSet.id = stateToSet.id ?? store?.getters.activeDocument?.id;
+
+    stateQueue.set( key, stateToSet );
     timeout = setTimeout( processQueue, ENQUEUE_TIMEOUT );
 };
 

--- a/src/store/actions/content-paste.ts
+++ b/src/store/actions/content-paste.ts
@@ -28,6 +28,7 @@ import { enqueueState } from "@/factories/history-state-factory";
 import LayerFactory from "@/factories/layer-factory";
 import { type BitMapperyState } from "@/store";
 import { cloneCanvas } from "@/utils/canvas-util";
+import { cloneLayer } from "@/utils/layer-util";
 import { getIndexOfLastLayerInTileGroup } from "@/utils/timeline-util";
 
 export const pasteCopiedContent = ( store: Store<BitMapperyState> ): void => {
@@ -43,7 +44,8 @@ export const pasteCopiedContent = ( store: Store<BitMapperyState> ): void => {
             return;
         
         case "layer":
-            const layers = copyContent.content as CopiedLayers;
+            // cloning is important in case we paste across Documents
+            const layers = ( copyContent.content as CopiedLayers ).map( layer => cloneLayer( layer, true ));
             const layerIndices = layers.map(( _layer: Layer, i: number ) => {
                 return insertIndex + i;
             });

--- a/src/store/modules/document-module.ts
+++ b/src/store/modules/document-module.ts
@@ -283,6 +283,7 @@ const DocumentModule: Module<DocumentState, any> = {
                     commit( "closeActiveDocument" );
                     commit( "removeImagesForDocument", activeDocument );
                     commit( "setActiveDocument", Math.min( state.documents.length - 1, state.activeIndex ));
+                    commit( "clearHistory", activeDocument.id );
                 },
                 cancel : () => true
             });

--- a/src/store/modules/history-module.ts
+++ b/src/store/modules/history-module.ts
@@ -65,13 +65,13 @@ const HistoryModule: Module<HistoryState, any> = {
     state: createHistoryState(),
     getters: {
         canUndo( state: HistoryState, rootGetters: any ): boolean {
-            if ( !rootGetters.activeDocument || !state.documents.has( rootGetters.activeDocument.id )) {
+            if ( !rootGetters.activeDocument ) {
                 return false;
             }
             return canUndo( state.documents.get( rootGetters.activeDocument.id ));
         },
         canRedo( state: HistoryState, rootGetters: any ): boolean {
-            if ( !rootGetters.activeDocument || !state.documents.has( rootGetters.activeDocument.id )) {
+            if ( !rootGetters.activeDocument ) {
                 return false;
             }
             return canRedo( state.documents.get( rootGetters.activeDocument.id ));

--- a/src/store/modules/history-module.ts
+++ b/src/store/modules/history-module.ts
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Igor Zinken 2016-2023 - https://www.igorski.nl
+ * Igor Zinken 2016-2026 - https://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -23,6 +23,7 @@
 // @ts-expect-error UndoManager has no types
 import UndoManager from "undo-manager";
 import type { ActionContext, Module } from "vuex";
+import type { Document } from "@/definitions/document";
 import { forceProcess, flushQueue } from "@/factories/history-state-factory";
 import type { UndoRedoState } from "@/factories/history-state-factory";
 import { getRendererForLayer } from "@/factories/renderer-factory";
@@ -30,11 +31,11 @@ import { disposeResource } from "@/utils/resource-manager";
 
 export const STATES_TO_SAVE = 99;
 
-export interface HistoryState {
+export interface DocumentHistory {
     undoManager: UndoManager;
-    historyIndex: number; // used for reactivity (as undo manager isn't bound to Vue)
+    historyIndex: number; // used for reactivity (as undo manager isn't bound to Vue), the last saved state index
     // states can specify an optional list of Blob URLs associated with their undo/redo
-    // operation. When such a state is popped from the avilable undo stack (because
+    // operation. When such a state is popped from the available undo stack (because
     // new states have been added beyond the STATES_TO_SAVE limit), these Blob URLs
     // are revoked to free up memory.
     blobUrls: Map<number, string[]>;
@@ -43,13 +44,17 @@ export interface HistoryState {
     stored: number;
 };
 
+export interface HistoryState {
+    documents: Map<string, DocumentHistory>;
+};
+
 export const createHistoryState = ( props?: Partial<HistoryState> ): HistoryState => ({
-    undoManager: null, // pass explicitly in props
-    historyIndex: -1,
-    blobUrls: new Map(),
-    stored: 0,
+    documents: new Map(),
     ...props,
 });
+
+const canUndo = ( history?: DocumentHistory ): boolean => history && history.historyIndex >= 0 && history.undoManager.hasUndo();
+const canRedo = ( history?: DocumentHistory ): boolean => history && history.historyIndex < STATES_TO_SAVE && history.undoManager.hasRedo();
 
 // a module to store states so the application can undo/redo changes
 // made to a document. We do this by applying save and restore functions for
@@ -57,58 +62,80 @@ export const createHistoryState = ( props?: Partial<HistoryState> ): HistoryStat
 // entire document structures as this will consume a large amount of memory!
 
 const HistoryModule: Module<HistoryState, any> = {
-    state: createHistoryState({ undoManager: new UndoManager() }),
+    state: createHistoryState(),
     getters: {
-        canUndo( state: HistoryState ): boolean {
-            return state.historyIndex >= 0 && state.undoManager.hasUndo();
+        canUndo( state: HistoryState, rootGetters: any ): boolean {
+            if ( !rootGetters.activeDocument || !state.documents.has( rootGetters.activeDocument.id )) {
+                return false;
+            }
+            return canUndo( state.documents.get( rootGetters.activeDocument.id ));
         },
-        canRedo( state: HistoryState ): boolean {
-            return state.historyIndex < STATES_TO_SAVE && state.undoManager.hasRedo();
-        },
-        amountOfStates( state: HistoryState ): number {
-            return state.historyIndex + 1;
+        canRedo( state: HistoryState, rootGetters: any ): boolean {
+            if ( !rootGetters.activeDocument || !state.documents.has( rootGetters.activeDocument.id )) {
+                return false;
+            }
+            return canRedo( state.documents.get( rootGetters.activeDocument.id ));
         },
     },
     mutations: {
+        registerDocument( state: HistoryState, activeDocument: Document ): void {
+            const { id } = activeDocument;
+            if ( state.documents.has( id )) {
+                return;
+            }
+            const undoManager = new UndoManager();
+            undoManager.setLimit( STATES_TO_SAVE );
+            state.documents.set( id, {
+                undoManager,
+                historyIndex: -1,
+                blobUrls: new Map(),
+                stored: 0,
+            });
+        },
         /**
-         * Store a state change inside the history.
+         * Store a state change inside the documents state history.
+         * This should not be called directly but must be deferred through history-state-factory#enqueueState !
          */
-        saveState( state: HistoryState, { undo, redo, resources = null }: UndoRedoState ): void {
-            state.undoManager.add({ undo, redo });
-            state.historyIndex = state.undoManager.getIndex();
-            ++state.stored;
-
-            const storedIndex = state.stored;
+        saveState( state: HistoryState, { id, undo, redo, resources = null }: UndoRedoState ): void {
+            const history = state.documents.get( id );
+            if ( !history ) {
+                return;
+            }
+            history.undoManager.add({ undo, redo });
+            history.historyIndex = history.undoManager.getIndex();
+            ++history.stored;
+            
+            const storedIndex = history.stored;
 
             if ( storedIndex > STATES_TO_SAVE ) {
                 // the minimum index that should still be available in the undo stack
                 const minIndex = storedIndex - STATES_TO_SAVE;
-                [ ...state.blobUrls.entries()].forEach(([ index, urls ]) => {
+                [ ...history.blobUrls.entries()].forEach(([ index, urls ]) => {
                     if ( index < minIndex ) {
                         ( urls as string[] ).forEach( url => disposeResource( url ));
-                        state.blobUrls.delete( index );
+                        history.blobUrls.delete( index );
                     }
                 });
             }
-
             if ( Array.isArray( resources )) {
-                state.blobUrls.set( storedIndex, resources );
+                history.blobUrls.set( storedIndex, resources );
             }
         },
-        setHistoryIndex( state: HistoryState, value: number ): void {
-            state.historyIndex = value;
+        setHistoryIndex( state: HistoryState, { id, index }: { id: string, index: number }): void {
+            state.documents.get( id )!.historyIndex = index;
         },
-        /**
-         * clears entire history
-         */
-        resetHistory( state: HistoryState ): void {
+        clearHistory( state: HistoryState, id: string ): void {
+            if ( !state.documents.has( id )) {
+                return;
+            }
             flushQueue();
-            state.undoManager.clear();
-            state.historyIndex = -1;
-            state.stored = 0;
-            state.blobUrls.forEach( urlList => urlList.forEach( url => disposeResource( url )));
-            state.blobUrls.clear();
-        }
+            const history = state.documents.get( id )!;
+            history.undoManager.clear();
+            history.blobUrls.forEach( urlList => urlList.forEach( url => disposeResource( url )));
+            history.blobUrls.clear();
+            
+            state.documents.delete( id );
+        },
     },
     actions: {
         /**
@@ -121,10 +148,16 @@ const HistoryModule: Module<HistoryState, any> = {
                 await drawableRenderer.storePaintState();
             }
             forceProcess();
+            const { id } = getters.activeDocument;
             return new Promise( resolve => {
-                if ( getters.canUndo ) {
-                    state.undoManager.undo();
-                    commit( "setHistoryIndex", state.undoManager.getIndex());
+                const history = state.documents.get( id );
+
+                if ( canUndo( history )) {
+                    history.undoManager.undo();
+                    commit( "setHistoryIndex", {
+                        id,
+                        index: history.undoManager.getIndex()
+                    });
                 }
                 resolve(); // always resolve, application should not break if history cannot be accessed
             });
@@ -133,20 +166,20 @@ const HistoryModule: Module<HistoryState, any> = {
          * apply the next stored state
          */
         redo({ state, getters, commit }: ActionContext<HistoryState, any> ): Promise<void> {
+            const { id } = getters.activeDocument;
             return new Promise( resolve => {
-                if ( getters.canRedo ) {
-                    state.undoManager.redo();
-                    commit( "setHistoryIndex", state.undoManager.getIndex() );
+                const history = state.documents.get( id );
+
+                if ( canRedo( history )) {
+                    history.undoManager.redo();
+                    commit( "setHistoryIndex", {
+                        id,
+                        index: history.undoManager.getIndex()
+                    });
                 }
                 resolve(); // always resolve, application should not break if history cannot be accesse
             });
         }
     }
 };
-
 export default HistoryModule;
-
-/* initialization */
-
-// @ts-expect-error undoManager has no types
-HistoryModule.state.undoManager.setLimit( STATES_TO_SAVE );

--- a/src/utils/layer-util.ts
+++ b/src/utils/layer-util.ts
@@ -103,10 +103,10 @@ export const cropLayerContent = async ( layer: Layer, cropRectangle: Rectangle )
     }
 };
 
-export const cloneLayer = ( layerToClone: Layer ): Layer => {
+export const cloneLayer = ( layerToClone: Layer, keepOrgName = false ): Layer => {
     return LayerFactory.create({
         ...cloneDeep( layerToClone ),
-        name: `${layerToClone.name} #2`,
+        name: keepOrgName ? layerToClone.name : `${layerToClone.name} #2`,
         source: cloneCanvas( layerToClone.source ),
         mask: layerToClone.mask ? cloneCanvas( layerToClone.mask ) : null
     });

--- a/tests/unit/factories/history-state-factory.spec.ts
+++ b/tests/unit/factories/history-state-factory.spec.ts
@@ -1,6 +1,11 @@
 import { it, describe, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { mockZCanvas } from "../mocks";
+
+mockZCanvas();
+
 import type { Store } from "vuex";
 import type { BitMapperyState } from "@/store";
+import DocumentFactory from "@/factories/document-factory";
 import { initHistory, hasQueue, queueLength, flushQueue, enqueueState } from "@/factories/history-state-factory";
 
 describe( "History state factory", () => {
@@ -8,9 +13,14 @@ describe( "History state factory", () => {
     let clearTimeoutSpy: MockInstance<typeof clearTimeout>;
     let store: Store<BitMapperyState>;
 
+    const activeDocument = DocumentFactory.create();
+
     beforeEach(() => {
         store = {
             commit: vi.fn(),
+            getters: {
+                activeDocument,
+            },
         } as unknown as Store<BitMapperyState>;
         initHistory( store );
 
@@ -40,22 +50,30 @@ describe( "History state factory", () => {
 
         it( "should start a timeout before adding an enqueued state to the history module", () => {
             enqueueState( "foo", mockUndoRedoState );
+
             expect( setTimeoutSpy ).toHaveBeenCalledTimes( 1 );
             expect( setTimeoutSpy ).toHaveBeenLastCalledWith( expect.any( Function ), 1000 );
         });
 
-        it( "should commit the enqueued state into the history module when the timeout fires", () => {
+        it( "should commit the enqueued state into the history module when the timeout fires, providing the active document id", () => {
             const historyState1 = { undo: vi.fn(), redo: vi.fn() };
+
             enqueueState( "foo", historyState1 );
+            
             vi.advanceTimersByTime( 1000 );
-            expect( store.commit ).toHaveBeenCalledWith( "saveState", historyState1 );
+            
+            expect( store.commit ).toHaveBeenCalledWith( "saveState", {
+                ...historyState1,
+                id: activeDocument.id,
+            });
         });
 
         it( "should be able to enqueue multiple states for different properties by immediately processing the pending queue", () => {
-            const historyState1 = { undo: vi.fn(), redo: vi.fn() };
-            const historyState2 = { undo: vi.fn(), redo: vi.fn() };
+            const historyState1 = { id: activeDocument.id, undo: vi.fn(), redo: vi.fn() };
+            const historyState2 = { id: activeDocument.id, undo: vi.fn(), redo: vi.fn() };
 
             enqueueState( "foo", historyState1 );
+
             expect( clearTimeoutSpy ).not.toHaveBeenCalled();
             expect( setTimeoutSpy ).toHaveBeenCalledTimes( 1 );
 
@@ -77,15 +95,15 @@ describe( "History state factory", () => {
         });
 
         it( "when enqueing multiple states for the same property, it should update the first entry's redo state and not add a new entry for the same property", () => {
-            const historyState1 = { undo: vi.fn(), redo: vi.fn() };
-            const historyState2 = { undo: vi.fn(), redo: vi.fn() };
+            const historyState1 = { id: activeDocument.id, undo: vi.fn(), redo: vi.fn() };
+            const historyState2 = { id: activeDocument.id, undo: vi.fn(), redo: vi.fn() };
 
             enqueueState( "foo", historyState1 );
             enqueueState( "foo", historyState2 );
 
             expect( queueLength() ).toBe( 1 );
 
-            // ensure the first queued state has updated its redo state to the lsat entry
+            // ensure the first queued state has updated its redo state to the last entry
             expect( historyState1.redo ).toEqual( historyState2.redo );
             // ensure the first queued state undo remains unchanged
             expect( historyState1.undo ).not.toEqual( historyState2.undo );

--- a/tests/unit/store/actions/content-paste.spec.ts
+++ b/tests/unit/store/actions/content-paste.spec.ts
@@ -130,8 +130,18 @@ describe( "content paste action", () => {
             pasteCopiedContent( store );
 
             expect( store.commit ).toHaveBeenCalledTimes( 2 );
-            expect( store.commit ).toHaveBeenNthCalledWith( 1, "insertLayerAtIndex", { index: 2, layer: copiedLayers[ 0 ] });
-            expect( store.commit ).toHaveBeenNthCalledWith( 2, "insertLayerAtIndex", { index: 3, layer: copiedLayers[ 1 ] });
+            expect( store.commit ).toHaveBeenNthCalledWith( 1, "insertLayerAtIndex", {
+                index: 2, layer: {
+                    ...copiedLayers[ 0 ],
+                    id: expect.any( String ),
+                }
+            });
+            expect( store.commit ).toHaveBeenNthCalledWith( 2, "insertLayerAtIndex", {
+                index: 3, layer: {
+                    ...copiedLayers[ 1 ],
+                    id: expect.any( String ),
+                }
+            });
         });
 
         it( "should be able to paste the Layers inside the active group of a timeline Document", () => {

--- a/tests/unit/store/modules/document-module.spec.ts
+++ b/tests/unit/store/modules/document-module.spec.ts
@@ -828,7 +828,7 @@ describe( "Vuex document module", () => {
         it( "should be able to flush all resources allocated to a Document when closing", () => {
             const state = createDocumentState({
                 documents: [ DocumentFactory.create(), DocumentFactory.create() ],
-                activeIndex: 1,
+                activeIndex: 0,
             });
             const commit = vi.fn();
             const getters = {
@@ -836,6 +836,7 @@ describe( "Vuex document module", () => {
                 t: vi.fn(),
             };
 
+            // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
             actions.requestDocumentClose({ state, commit, getters });
 
             expect( commit ).toHaveBeenCalledTimes( 1 );

--- a/tests/unit/store/modules/document-module.spec.ts
+++ b/tests/unit/store/modules/document-module.spec.ts
@@ -7,7 +7,7 @@ import LayerFactory from "@/factories/layer-factory";
 import DocumentModule, { createDocumentState, type DocumentState } from "@/store/modules/document-module";
 import LayerRenderer from "@/rendering/actors/layer-renderer";
 
-const { getters, mutations } = DocumentModule;
+const { getters, mutations, actions } = DocumentModule;
 
 mockZCanvas();
 
@@ -821,6 +821,36 @@ describe( "Vuex document module", () => {
                 unit: "px",
                 swatches: [],
             });
+        });
+    });
+
+    describe( "actions", () => {
+        it( "should be able to flush all resources allocated to a Document when closing", () => {
+            const state = createDocumentState({
+                documents: [ DocumentFactory.create() ],
+                activeIndex: 1,
+            });
+            const commit = vi.fn();
+            const getters = {
+                activeDocument: state.documents[ 0 ],
+                t: vi.fn(),
+            };
+
+            actions.requestDocumentClose({ state, commit, getters });
+
+            expect( commit ).toHaveBeenCalledTimes( 1 );
+            expect( commit ).toHaveBeenCalledWith( "openDialog", expect.any( Object ));
+
+            // grab the Dialog window request actions and confirm Document close
+            const { confirm } = commit.mock.calls[ 0 ][ 1 ];
+            confirm();
+
+            expect( commit ).toHaveBeenCalledTimes( 5 );
+
+            expect( commit ).toHaveBeenCalledWith( "closeActiveDocument" );
+            expect( commit ).toHaveBeenCalledWith( "removeImagesForDocument", getters.activeDocument );
+            expect( commit ).toHaveBeenCalledWith( "setActiveDocument", 0 );
+            expect( commit ).toHaveBeenCalledWith( "clearHistory", getters.activeDocument.id );
         });
     });
 });

--- a/tests/unit/store/modules/document-module.spec.ts
+++ b/tests/unit/store/modules/document-module.spec.ts
@@ -827,7 +827,7 @@ describe( "Vuex document module", () => {
     describe( "actions", () => {
         it( "should be able to flush all resources allocated to a Document when closing", () => {
             const state = createDocumentState({
-                documents: [ DocumentFactory.create() ],
+                documents: [ DocumentFactory.create(), DocumentFactory.create() ],
                 activeIndex: 1,
             });
             const commit = vi.fn();

--- a/tests/unit/store/modules/history-module.spec.ts
+++ b/tests/unit/store/modules/history-module.spec.ts
@@ -1,7 +1,6 @@
 import { it, describe, expect, beforeEach, afterAll, vi } from "vitest";
 import { mockZCanvas } from "../../mocks";
-// @ts-expect-error UndoManager has no types
-import UndoManager from "undo-manager";
+import DocumentFactory from "@/factories/document-factory";
 import store, { createHistoryState, type HistoryState, STATES_TO_SAVE } from "@/store/modules/history-module";
 const { getters, mutations, actions }  = store;
 
@@ -19,203 +18,366 @@ describe( "History State module", () => {
     const noop = () => {};
     let commit = vi.fn();
     let state: HistoryState;
+    const document1 = DocumentFactory.create();
+    const document2 = DocumentFactory.create();
 
     beforeEach( () => {
-        state = createHistoryState({
-            undoManager: new UndoManager(),
-            historyIndex: -1,
-            blobUrls: new Map(),
-            stored: 0,
-        });
-        state.undoManager.setLimit( STATES_TO_SAVE );
+        state = createHistoryState();
     });
 
     afterAll(() => {
         vi.clearAllMocks();
     });
 
-    describe("getters", () => {
-        it("should know when it can undo an action", async () => {
-            expect(getters.canUndo(state, { canUndo: state.undoManager.hasUndo() }, {}, {})).toBe(false); // expected no undo to be available after construction
+    describe( "getters", () => {
+        it( "should know when it can undo an action", async () => {
+            mutations.registerDocument( state, document1 ); // register document in history
+
+            expect(
+                getters.canUndo(
+                    state, { activeDocument: undefined }, {}, {}
+                )
+            ).toBe( false ); // expected no undo to be available when there is no active Document
+
+            expect(
+                getters.canUndo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( false ); // expected no undo to be available when active Document hasn't saved states yet
             
-            mutations.saveState(state, { undo: noop, redo: noop });
+            mutations.saveState( state, { id: document1.id, undo: noop, redo: noop });
             
-            expect(getters.canUndo(state, { canUndo: state.undoManager.hasUndo() }, {}, {})).toBe(true); // expected undo to be available after addition of action
+            expect(
+                getters.canUndo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( true ); // expected undo to be available after addition of action
             
             // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-            await actions.undo({ state, commit, getters: { canUndo: state.undoManager.hasUndo() }});
+            await actions.undo({ state, commit, getters: { activeDocument: document1 }});
             
-            expect(getters.canUndo(state, { canUndo: state.undoManager.hasUndo() }, {}, {})).toBe(false); // expected no undo to be available after having undone all actions
+            expect(
+                getters.canUndo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( false ); // expected no undo to be available after having undone all actions
         });
 
-        it("should know when it can redo an action", async () => {
-            expect(getters.canRedo(state, getters, {}, {})).toBe(false); // expected no redo to be available after construction
-            
-            mutations.saveState(state, { undo: noop, redo: noop });
-            
-            expect(getters.canRedo(state, getters, {}, {})).toBe(false); // expected no redo to be available after addition of action
-            
-            // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-            await actions.undo({ state, commit, getters: { canUndo: state.undoManager.hasUndo() }});
-            
-            expect(getters.canRedo(state, getters, {}, {})).toBe(true); // expected redo to be available after having undone actions
-            
-            // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-            await actions.redo({ state, commit, getters: { canRedo: state.undoManager.hasRedo() }});
+        it( "should know when it can redo an action", async () => {
+            mutations.registerDocument( state, document1 ); // register document in history
 
-            expect(getters.canRedo(state, getters, {}, {})).toBe(false); // expected no redo to be available after having redone all actions
+            expect(
+                getters.canRedo(
+                    state, { activeDocument: undefined }, {}, {}
+                )
+            ).toBe( false ); // expected no redo to be available when there is no active Document
+
+            expect(
+                getters.canRedo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( false ); // expected no redo to be available when active Document hasn't saved states yet
+            
+            mutations.saveState( state, { id: document1.id, undo: noop, redo: noop });
+            
+            expect(
+                getters.canRedo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( false ); // expected no redo to be available after addition of action
+            
+            // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
+            await actions.undo({ state, commit, getters: { activeDocument: document1 }});
+            
+            expect(
+                getters.canRedo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( true ); // expected redo to be available after having undone actions
+            
+            // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
+            await actions.redo({ state, commit, getters: { activeDocument: document1 }});
+
+            expect(
+                getters.canRedo(
+                    state, { activeDocument: document1 }, {}, {}
+                )
+            ).toBe( false ); // expected no redo to be available after having redone all actions
         });
 
-        it("should know the amount of states it can restore", async () => {
-            // @ts-expect-error Mock<Procedure>
-            commit = (_action, value) => state.historyIndex = value;
-            expect(0).toEqual(getters.amountOfStates(state, getters, {}, {})); // expected no states to be present after construction
+        it( "should know when it can undo an action when switching between Documents", async () => {
+            mutations.registerDocument( state, document1 );
+            mutations.registerDocument( state, document2 );
 
-            for ( let i = 0; i < STATES_TO_SAVE; ++i ) {
-                mutations.saveState(state, { undo: noop, redo: noop });
-                expect(i + 1).toEqual(getters.amountOfStates(state, getters, {}, {})); // expected amount of states to increase when storing new states
-            }
+            await mutations.saveState( state, { id: document1.id, undo: noop, redo: noop });
 
-            for ( let i = STATES_TO_SAVE - 1; i >= 0; --i ) {
-                // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-                await actions.undo({ state, commit, getters: { canUndo: state.undoManager.hasUndo() }});
-                expect(i).toEqual(getters.amountOfStates(state, getters, {}, {})); // expected amount of states to decrease when performing undo
-            }
+            expect( getters.canUndo( state, { activeDocument: document1 }, {}, {} )).toBe( true ); // state saved for document 1
+            expect( getters.canUndo( state, { activeDocument: document2 }, {}, {} )).toBe( false ); // no state saved for document 2
+        });
 
-            for ( let i = 0; i < STATES_TO_SAVE; ++i ) {
-                // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-                await actions.redo({ state, commit, getters: { canRedo: state.undoManager.hasRedo() }});
-                expect(i + 1).toEqual(getters.amountOfStates(state, getters, {}, {})); // expected amount of states to increase when performing redo
-            }
+        it( "should know when it can redo an action when switching between Documents", async () => {
+            mutations.registerDocument( state, document1 );
+            mutations.registerDocument( state, document2 );
+
+            mutations.saveState( state, { id: document1.id, undo: noop, redo: noop });
+            mutations.saveState( state, { id: document2.id, undo: noop, redo: noop });
+
+            // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
+            await actions.undo({ state, commit, getters: { activeDocument: document1 }});
+
+            expect( getters.canRedo( state, { activeDocument: document1 }, {}, {} )).toBe( true ); // redo available after undo of action for document 1
+            expect( getters.canRedo( state, { activeDocument: document2 }, {}, {} )).toBe( false ); // redo not available for document 2
         });
 
         it( "should keep track of the total amount of states registered, even when popped from the stack", () => {
+            const { id } = document1;
+            mutations.registerDocument( state, document1 );
+
             for ( let i = 0; i < STATES_TO_SAVE * 2; ++i ) {
-                mutations.saveState(state, { undo: noop, redo: noop });
+                mutations.saveState( state, { id, undo: noop, redo: noop });
             }
-            expect( state.stored ).toEqual( STATES_TO_SAVE * 2 ); // total counts the cumulatives
-            expect( getters.amountOfStates( state, getters, {}, {} )).toEqual( STATES_TO_SAVE ); // states never exceed the total
+            expect( state.documents.get( id ).stored ).toEqual( STATES_TO_SAVE * 2 ); // counts the cumulatives
+            expect( state.documents.get( id ).historyIndex ).toEqual( STATES_TO_SAVE - 1 ); // never exceeds the total
         });
     });
 
     describe( "mutations", () => {
+        describe( "when registering a new Document", () => {
+            it( "should register a new history structure for it", () => {
+                expect( state.documents.size ).toEqual( 0 );
+
+                mutations.registerDocument( state, document1 );
+
+                expect( state.documents.size ).toEqual( 1 );
+                expect( state.documents.get( document1.id )).toEqual({
+                    undoManager: expect.any( Object ),
+                    historyIndex: -1,
+                    blobUrls: expect.any( Map ),
+                    stored: 0, 
+                });
+            });
+
+            it( "should not register the same Document twice", () => {
+                mutations.registerDocument( state, document1 );
+                mutations.registerDocument( state, document1 );
+
+                expect( state.documents.size ).toEqual( 1 );
+            });
+
+            it( "should be able to register multiple Documents with their own history structure", () => {
+                mutations.registerDocument( state, document1 );
+                mutations.registerDocument( state, document2 );
+
+                expect( state.documents.size ).toEqual( 2 );
+            });
+        });
+
         describe( "when saving states", () => {
-            it( "should be able to store a state and increment the history index", () => {
-                mutations.saveState( state, { undo: noop, redo: noop });
-                expect( state.historyIndex ).toEqual( 0 );
-                mutations.saveState( state, { undo: noop, redo: noop });
-                expect( state.historyIndex ).toEqual( 1 );
+            it( "should be able to store a state and increment the history index for a Document", () => {
+                mutations.registerDocument( state, document1 );
+                const { id } = document1;
+
+                mutations.saveState( state, { id, undo: noop, redo: noop });
+
+                expect( state.documents.get( id ).historyIndex ).toEqual( 0 );
+                
+                mutations.saveState( state, { id, undo: noop, redo: noop });
+                
+                expect( state.documents.get( id ).historyIndex ).toEqual( 1 );
+            });
+
+            it( "should be able to individually manage states and history indices for different Documents", () => {
+                mutations.registerDocument( state, document1 );
+                mutations.registerDocument( state, document2 );
+
+                mutations.saveState( state, { id: document1.id, undo: noop, redo: noop });
+                mutations.saveState( state, { id: document1.id, undo: noop, redo: noop });
+                
+                mutations.saveState( state, { id: document2.id, undo: noop, redo: noop });
+                mutations.saveState( state, { id: document2.id, undo: noop, redo: noop });
+                mutations.saveState( state, { id: document2.id, undo: noop, redo: noop });
+                
+                expect( state.documents.get( document1.id ).historyIndex ).toEqual( 1 );
+                expect( state.documents.get( document2.id ).historyIndex ).toEqual( 2 );
             });
 
             it( "should not store more states than are allowed", () => {
+                mutations.registerDocument( state, document1 );
+                const { id } = document1;
+
                 for ( let i = 0; i < STATES_TO_SAVE * 2; ++i ) {
-                    mutations.saveState( state, { undo: noop, redo: noop });
+                    mutations.saveState( state, { id, undo: noop, redo: noop });
                 }
-                // expected model to not have recorded more states than the defined maximum
-                expect( getters.amountOfStates( state, getters, {}, {} )).toEqual( STATES_TO_SAVE );
+                expect( state.documents.get( id ).historyIndex ).toEqual( STATES_TO_SAVE - 1 );
+                expect( state.documents.get( id ).stored ).toEqual( STATES_TO_SAVE * 2 );
             });
 
             it( "should be able to store a list of optional Blob resources within a state", () => {
-                expect( state.blobUrls.size ).toEqual( 0 );
+                const { id } = document1;
+                mutations.registerDocument( state, document1 );
 
-                mutations.saveState( state, { undo: noop, redo: noop, resources: [ "foo" ] });
-                mutations.saveState( state, { undo: noop, redo: noop });
-                mutations.saveState( state, { undo: noop, redo: noop, resources: [ "bar", "baz" ]});
+                const documentHistory = state.documents.get( id );
 
-                expect( state.blobUrls.size ).toEqual( 2 );
+                expect( documentHistory.blobUrls.size ).toEqual( 0 ); // no URLS upon registration
 
-                expect( state.blobUrls.get( 1 )).toEqual([ "foo" ]);
-                expect( state.blobUrls.get( 3 )).toEqual([ "bar", "baz" ]);
+                mutations.saveState( state, { id, undo: noop, redo: noop, resources: [ "foo" ] });
+                mutations.saveState( state, { id, undo: noop, redo: noop });
+                mutations.saveState( state, { id, undo: noop, redo: noop, resources: [ "bar", "baz" ]});
+
+                expect( documentHistory.blobUrls.size ).toEqual( 2 );
+
+                expect( documentHistory.blobUrls.get( 1 )).toEqual([ "foo" ]);
+                expect( documentHistory.blobUrls.get( 3 )).toEqual([ "bar", "baz" ]);
             });
 
             it( "should free memory associated with optional Blob resources of popped states", () => {
+                const { id } = document1;
+                mutations.registerDocument( state, document1 );
+
                 mockUpdateFn = vi.fn();
 
                 // add enough states to exceed the limit to pop old states
                 for ( let i = 0; i < STATES_TO_SAVE + 2; ++i ) {
                     // only add resources to first two states
                     const resources = ( i < 2 ) ? [ `resource_${i}`, `resource__${i}` ] : null;
-                    mutations.saveState( state, { undo: noop, redo: noop, resources });
+                    mutations.saveState( state, { id, undo: noop, redo: noop, resources });
                 }
+
+                const documentHistory = state.documents.get( id );
+
                 // assert the first state's resources have been freed while the second still exist
-                expect( state.blobUrls.size ).toEqual( 1 );
-                expect( state.blobUrls.has( 2 )).toBe( true ); // index of second, still available state
+                expect( documentHistory.blobUrls.size ).toEqual( 1 );
+                expect( documentHistory.blobUrls.has( 2 )).toBe( true ); // index of second, still available state
                 expect( mockUpdateFn ).toHaveBeenNthCalledWith( 1, "disposeResource", "resource_0" );
                 expect( mockUpdateFn ).toHaveBeenNthCalledWith( 2, "disposeResource", "resource__0" );
 
                 // push one more state to pop the second added state from the available undo stack
-                mutations.saveState( state, { undo: noop, redo: noop });
+                mutations.saveState( state, { id, undo: noop, redo: noop });
 
                 // assert the second state's resource have also been freed and no further
                 // resources are listed (as no other states were stored with associated resources)
-                expect( state.blobUrls.size ).toEqual( 0 );
-                expect( state.blobUrls.has( 2 )).toBe( false );
+                expect( documentHistory.blobUrls.size ).toEqual( 0 );
+                expect( documentHistory.blobUrls.has( 2 )).toBe( false );
                 expect( mockUpdateFn ).toHaveBeenNthCalledWith( 3, "disposeResource", "resource_1" );
                 expect( mockUpdateFn ).toHaveBeenNthCalledWith( 4, "disposeResource", "resource__1" );
             });
         });
 
-        it( "should be able to set the history index", () => {
-            mutations.setHistoryIndex(state, 2);
-            expect(state.historyIndex).toEqual(2);
+        it( "should be able to set the history index for a specific Document", () => {
+            mutations.registerDocument( state, document1 );
+            mutations.registerDocument( state, document2 );
+
+            mutations.setHistoryIndex( state, { id: document1.id, index: 2 });
+            mutations.setHistoryIndex( state, { id: document2.id, index: 30 });
+
+            expect( state.documents.get( document1.id ).historyIndex ).toEqual( 2 );
+            expect( state.documents.get( document2.id ).historyIndex ).toEqual( 30 );
         });
 
-        it("should be able to clear its history and allocated state resources", () => {
-            mockUpdateFn = vi.fn();
+        describe( "when clearing Document history", () => {
+            it( "should be able to clear a Documents history and allocated state resources", () => {
+                const { id } = document1;
+                mutations.registerDocument( state, document1 );
 
-            function shouldntRun() {
-                throw new Error( "undo/redo callback should not have fired after clearing the undo history" );
-            }
-            mutations.saveState(state, { undo: shouldntRun, redo: shouldntRun, resources: [ "foo", "bar" ] });
-            mutations.saveState(state, { undo: shouldntRun, redo: shouldntRun, resources: [ "baz" ] });
+                const documentHistory = state.documents.get( id );
+                
+                mockUpdateFn = vi.fn();
 
-            mutations.resetHistory( state );
+                function shouldntRun() {
+                    throw new Error( "undo/redo callback should not have fired after clearing the undo history" );
+                }
+                mutations.saveState( state, { id, undo: shouldntRun, redo: shouldntRun, resources: [ "foo", "bar" ] });
+                mutations.saveState( state, { id, undo: shouldntRun, redo: shouldntRun, resources: [ "baz" ] });
 
-            expect( mockUpdateFn ).toHaveBeenNthCalledWith( 1, "flushQueue" );
-            expect( state.historyIndex ).toEqual( -1 );
-            expect( getters.canUndo( state, getters, {}, {} )).toBe( false ); // expected no undo to be available after flushing of history
-            expect( getters.canRedo( state, getters, {}, {} )).toBe( false ); // expected no redo to be available after flushing of history
-            expect( getters.amountOfStates( state, getters, {}, {} )).toEqual( 0 ); // expected no states to be present in history
-            expect( state.stored ).toEqual( 0 );
+                expect( documentHistory.blobUrls.size ).toEqual( 2 ); // sanity check that Blobs were registerd
 
-            expect( mockUpdateFn ).toHaveBeenNthCalledWith( 2, "disposeResource", "foo" );
-            expect( mockUpdateFn ).toHaveBeenNthCalledWith( 3, "disposeResource", "bar" );
-            expect( mockUpdateFn ).toHaveBeenNthCalledWith( 4, "disposeResource", "baz" );
+                mutations.clearHistory( state, id );
 
-            expect( state.blobUrls.size ).toEqual( 0 );
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 1, "flushQueue" );
+                expect( state.documents.has( id )).toBe( false ); // ensure history is removed from Map
+                
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 2, "disposeResource", "foo" );
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 3, "disposeResource", "bar" );
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 4, "disposeResource", "baz" );
+                expect( documentHistory.blobUrls.size ).toEqual( 0 ); // ensure Blob references are cleared from original history object
+            });
+
+            it( "should be able to clear individual Document history and resources", () => {
+                mutations.registerDocument( state, document1 );
+                mutations.registerDocument( state, document2 );
+
+                mockUpdateFn = vi.fn();
+
+                mutations.saveState( state, { id: document1.id, undo: noop, redo: noop, resources: [ "foo", "bar" ] });
+                mutations.saveState( state, { id: document2.id, undo: noop, redo: noop, resources: [ "baz" ] });
+                mutations.saveState( state, { id: document2.id, undo: noop, redo: noop, resources: [ "qux" ] });
+
+                // sanity check that Blobs were registered
+
+                expect( state.documents.get( document1.id ).blobUrls.size ).toEqual( 1 );
+                expect( state.documents.get( document2.id ).blobUrls.size ).toEqual( 2 );
+
+                mutations.clearHistory( state, document1.id );
+
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 1, "flushQueue" );
+
+                expect( state.documents.has( document1.id )).toBe( false ); // ensure history for Document 1 is removed from the Map
+                expect( state.documents.has( document2.id )).toBe( true ); // ensure history for Document 2 remains in the Map
+
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 2, "disposeResource", "foo" );
+                expect( mockUpdateFn ).toHaveBeenNthCalledWith( 3, "disposeResource", "bar" );
+                expect( mockUpdateFn ).not.toHaveBeenCalledWith( "disposeResource", "baz" );
+                expect( mockUpdateFn ).not.toHaveBeenCalledWith( "disposeResource", "qux" );
+
+                expect( state.documents.get( document2.id ).blobUrls.size ).toEqual( 2 ); // ensure Document 2 Blobs remain registered
+
+                mutations.clearHistory( state, document2.id );
+
+                expect( state.documents.has( document2.id )).toBe( false ); // ensure history for Document 2 is removed from the Map
+
+                expect( mockUpdateFn ).toHaveBeenCalledWith( "disposeResource", "baz" );
+                expect( mockUpdateFn ).toHaveBeenCalledWith( "disposeResource", "qux" );
+            });
         });
     });
 
-    describe("actions", () => {
-        it("should be able to redo an action", async () => {
+    describe( "actions", () => {
+        it( "should be able to redo an action", async () => {
+            const { id } = document1;
+            mutations.registerDocument( state, document1 );
+
             commit = vi.fn();
             const redo = vi.fn();
-            mutations.saveState(state, { undo: noop, redo: redo });
+
+            mutations.saveState( state, { id, undo: noop, redo: redo });
 
             // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-            await actions.undo({ state, commit, getters: { canUndo: state.undoManager.hasUndo() }});
+            await actions.undo({ state, commit, getters: { activeDocument: document1 }});
 
-            expect(commit).toHaveBeenNthCalledWith(1, "setHistoryIndex", -1);
+            expect( commit ).toHaveBeenNthCalledWith( 1, "setHistoryIndex", { id: document1.id, index: -1 });
 
             // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-            await actions.redo({ state, commit, getters: { canRedo: state.undoManager.hasRedo() }});
+            await actions.redo({ state, commit, getters: { activeDocument: document1 }});
 
-            expect(redo).toHaveBeenCalled();
-            expect(commit).toHaveBeenNthCalledWith(2, "setHistoryIndex", 0);
+            expect( redo ).toHaveBeenCalled();
+            expect( commit ).toHaveBeenNthCalledWith( 2, "setHistoryIndex", { id: document1.id, index: 0 });
         });
 
-        it("should be able to undo an action when an action was stored in its state history", async () => {
-            mockUpdateFn = vi.fn();
+        it( "should be able to undo an action when an action was stored in its state history", async () => {
+            const { id } = document1;
+            mutations.registerDocument( state, document1 );
 
+            mockUpdateFn = vi.fn();
             const undo = vi.fn();
-            mutations.saveState(state, { undo: undo, redo: noop });
+
+            mutations.saveState( state, { id, undo: undo, redo: noop });
 
             // @ts-expect-error Not all constituents of type 'Action<HistoryState, any>' are callable.
-            await actions.undo({ state, commit, getters: { canUndo: state.undoManager.hasUndo() }});
+            await actions.undo({ state, commit, getters: { activeDocument: document1 }});
 
-            expect(mockUpdateFn).toHaveBeenCalledWith( "forceProcess" );
-            expect(undo).toHaveBeenCalled();
-            expect(state.historyIndex).toEqual(0);
+            expect( mockUpdateFn ).toHaveBeenCalledWith( "forceProcess" );
+            expect( undo ).toHaveBeenCalled();
+            expect( state.documents.get( id ).historyIndex).toEqual( 0 );
         });
     });
 });


### PR DESCRIPTION
### Motivation

Long overdue.

State history would only work for the active Document. When opening a new Document (without closing the existing one), the state history would be flushed and initiated anew for every change made in the currently focused Document.

This changeset introduces a state history unique to the Document, meaning you can switch between open Documents and maintain the history associated with your changes.