### PR TITLE
Fix issue where conflicting keyboard shortcuts would prevent layer panel navigation

### DIFF
--- a/src/components/layer-effects/layer-effects.vue
+++ b/src/components/layer-effects/layer-effects.vue
@@ -313,7 +313,6 @@ export default {
         this.orgFilters = clone( this.filters );
         this.internalValue = clone( this.filters );
         this.maxBlur = MAX_BLUR;
-        KeyboardService.setListener( this.handleKeyUp.bind( this ));
     },
     mounted(): void {
         const { scrollHeight } = this.$refs.effectsList;
@@ -321,22 +320,12 @@ export default {
             this.setLayersMaximized( true );
         }
     },
-    beforeUnmount(): void {
-        KeyboardService.setListener( null );
-    },
     methods: {
         ...mapMutations([
             "closeModal",
             "setLayersMaximized",
             "updateLayer",
         ]),
-        handleKeyUp( _type: string, keyCode: number ): boolean {
-            if ( keyCode === 27 ) {
-                this.cancel();
-                return true;
-            }
-            return false;
-        },
         save(): void {
             const filters = this.internalValue;
             if ( isEqual( filters, this.orgFilters )) {

--- a/src/components/layer-effects/layer-effects.vue
+++ b/src/components/layer-effects/layer-effects.vue
@@ -192,7 +192,6 @@ import { Filters } from "@/model/types/filters";
 import { BlendModes } from "@/definitions/blend-modes";
 import FiltersFactory from "@/model/factories/filters-factory";
 import { MAX_BLUR } from "@/rendering/filters/blur";
-import KeyboardService from "@/services/keyboard-service";
 import { updateLayerFilters } from "@/model/actions/layer-update-filters";
 import { clone } from "@/utils/object-util";
 

--- a/src/components/layer-effects/layer-effects.vue
+++ b/src/components/layer-effects/layer-effects.vue
@@ -313,7 +313,7 @@ export default {
         this.orgFilters = clone( this.filters );
         this.internalValue = clone( this.filters );
         this.maxBlur = MAX_BLUR;
-        KeyboardService.setListener( this.handleKeyUp.bind( this ), false );
+        KeyboardService.setListener( this.handleKeyUp.bind( this ));
     },
     mounted(): void {
         const { scrollHeight } = this.$refs.effectsList;
@@ -330,10 +330,12 @@ export default {
             "setLayersMaximized",
             "updateLayer",
         ]),
-        handleKeyUp( _type: string, keyCode: number ): void {
+        handleKeyUp( _type: string, keyCode: number ): boolean {
             if ( keyCode === 27 ) {
                 this.cancel();
+                return true;
             }
+            return false;
         },
         save(): void {
             const filters = this.internalValue;

--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -25,7 +25,9 @@
         tabindex="1"
         class="layer-panel-wrapper"
         :class="{ collapsed }"
+        @click="handleFocus()"
         @focus="handleFocus()"
+        @focusout="handleBlur()"
         @blur="handleBlur()"
     >
         <div class="component__header">
@@ -35,7 +37,7 @@
             <button
                 type="button"
                 class="component__header-button"
-                @click="collapsed = !collapsed"
+                @click.stop="collapsed = !collapsed"
             >{{ collapsed ? '+' : '-' }}</button>
         </div>
         <template v-if="!collapsed">
@@ -95,7 +97,7 @@
                                         'layer--selected': isSelectedLayer( element ),
                                     }"
                                     @dblclick="handleLayerDoubleClick( element )"
-                                    @click="handleLayerClick( element, $event )"
+                                    @click.stop="handleLayerClick( element, $event )"
                                 >{{ element.name }}</span>
                                 <div class="layer__actions">
                                     <!-- optional layer mask -->
@@ -106,26 +108,26 @@
                                         :class="{
                                             'layer__actions-button--highlight': element.maskSelected
                                         }"
-                                        @click="handleLayerMaskClick( element )"
+                                        @click.stop="handleLayerMaskClick( element )"
                                     ><img src="@/assets-inline/images/icon-mask.svg" /></button>
                                     <button
                                         v-tooltip="$t('toggleVisibility')"
                                         type="button"
                                         class="layer__actions-button button--ghost"
-                                        @click="handleToggleLayerVisibility( element.index )"
+                                        @click.stop="handleToggleLayerVisibility( element.index )"
                                         :class="{ 'layer__actions-button--disabled': !element.visible }"
                                     ><img src="@/assets-inline/images/icon-eye.svg" /></button>
                                     <button
                                         v-tooltip="$t('effectsAndFilters')"
                                         type="button"
                                         class="layer__actions-button button--ghost"
-                                        @click="handleEffectsClick( element.index )"
+                                        @click.stop="handleEffectsClick( element.index )"
                                     ><img src="@/assets-inline/images/icon-settings.svg" /></button>
                                     <button
                                         v-tooltip="$t( element.mask ? 'deleteMask' : 'deleteLayer' )"
                                         type="button"
                                         class="layer__actions-button button--ghost"
-                                        @click="handleRemoveClick( element.index )"
+                                        @click.stop="handleRemoveClick( element.index )"
                                         :class="{ 'layer__actions-button--disabled': !canDelete }"
                                     ><img src="@/assets-inline/images/icon-trashcan.svg" /></button>
                                 </div>
@@ -145,14 +147,14 @@
                     type="button"
                     class="button button--small"
                     :disabled="!activeDocument"
-                    @click="requestLayerAdd()"
+                    @click.stop="requestLayerAdd()"
                 ></button>
                 <button
                     v-t="'addMask'"
                     type="button"
                     class="button button--small"
                     :disabled="!activeLayer || currentLayerHasMask"
-                    @click="requestMaskAdd()"
+                    @click.stop="requestMaskAdd()"
                 ></button>
             </div>
             <context-menu
@@ -172,7 +174,6 @@ import { defineAsyncComponent } from "vue";
 import { mapState, mapGetters, mapMutations, mapActions } from "vuex";
 import { ADD_LAYER } from "@/definitions/modal-windows";
 import { PANEL_LAYERS } from "@/definitions/panel-types";
-import ToolTypes from "@/definitions/tool-types";
 import type { Layer } from "@/definitions/types/document";
 import { cutLayerContent } from "@/model/actions/content-cut-layers";
 import { removeLayer } from "@/model/actions/layer-remove";
@@ -387,7 +388,7 @@ export default {
             this.setActiveLayerIndex( this.layers.findIndex(({ id }) => id === layer.id ));
         },
         handleFocus(): void {
-            KeyboardService.setListener( this.handleKeyboard.bind( this ), false );
+            KeyboardService.setListener( this.handleKeyboard.bind( this ));
         },
         handleBlur(): void {
             KeyboardService.setListener( null );
@@ -406,9 +407,15 @@ export default {
                 case 13: // enter
                     this.handleEffectsClick( this.activeLayerIndex );
                     break;
+                case 9: // tab
+                    this.handleBlur();
+                    break;
                 case 27: // escape
-                    this.setEditable( false );
-                    this.showEffects = false;
+                    if ( this.showEffects ) {
+                        this.showEffects = false;
+                    } else {
+                        this.handleBlur();
+                    }
                     break;
                 case 32: // spacebar
                     this.handleToggleLayerVisibility( this.activeLayerIndex );
@@ -475,6 +482,8 @@ export default {
                 await this.$nextTick(); // allow component to update with input field
                 focus( this.$refs.nameInput );
                 this.$refs.nameInput?.select();
+            } else if ( !value ) {
+                this.handleFocus();
             }
         },
         showContextMenu( event: PointerEvent, layer: IndexedLayer ): void {

--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -25,6 +25,7 @@
         class="layer-panel-wrapper"
         :class="{ collapsed }"
         @blur="handleBlur()"
+        @focusout="handleBlur()"
     >
         <div class="component__header">
             <h2
@@ -33,7 +34,7 @@
             <button
                 type="button"
                 class="component__header-button"
-                @click.stop="collapsed = !collapsed"
+                @click="collapsed = !collapsed"
             >{{ collapsed ? '+' : '-' }}</button>
         </div>
         <template v-if="!collapsed">
@@ -387,6 +388,7 @@ export default {
         handleLayerDrag( dragEvent: { moved: { element: Layer, newIndex: number, oldIndex: number }}): void {
             const layer = dragEvent.moved.element;
             this.setActiveLayerIndex( this.layers.findIndex(({ id }) => id === layer.id ));
+            this.handleFocus();
         },
         handleFocus(): void {
             KeyboardService.setListener( this.handleKeyboard.bind( this ));

--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -189,8 +189,6 @@ import { focus } from "@/utils/environment-util";
 import { getLayersByTile } from "@/utils/timeline-util";
 import messages from "./messages.json";
 
-const NON_OVERRIDABLE_TOOLS = [ ToolTypes.MOVE, ToolTypes.DRAG ];
-
 type IndexedLayer = Layer & { index: number, maskSelected: boolean };
 
 export default {
@@ -258,9 +256,6 @@ export default {
         },
         currentLayerHasMask(): boolean {
             return !!this.activeLayer?.mask;
-        },
-        overrideCustomKeyHandler(): boolean {
-            return this.hasSelection || NON_OVERRIDABLE_TOOLS.includes( this.activeTool );
         },
         renderThumbnails(): boolean {
             return this.preferences.thumbnails;
@@ -397,13 +392,13 @@ export default {
         handleBlur(): void {
             KeyboardService.setListener( null );
         },
-        handleKeyboard( type: string, keyCode: number, event: KeyboardEvent ): void {
-            if ( type !== "down" || this.overrideCustomKeyHandler ) {
-                return;
+        handleKeyboard( type: string, keyCode: number, event: KeyboardEvent ): boolean {
+            if ( type !== "down" ) {
+                return false;
             }
             switch ( keyCode ) {
                 default:
-                    return;
+                    return false;
                 case 8:  // backspace
                 case 46: // delete
                     this.requestLayerRemove( this.activeLayerIndex );
@@ -456,19 +451,19 @@ export default {
                     break;
                 case 67: // C
                     if ( !KeyboardService.hasOption( event )) {
-                        return;
+                        return false;
                     }
                     this.requestLayerCopy( this.reverseLayers.filter( layer => this.isSelectedLayer( layer )).reverse());
                     break;
                 case 88: // X
                     if ( !KeyboardService.hasOption( event )) {
-                        return;
+                        return false;
                     }
                     cutLayerContent( this.$store, this.reverseLayers.filter( layer => this.isSelectedLayer( layer )).reverse());
                     this.resetSelectedLayers();
                     break;
             }
-            event.preventDefault();
+            return true;
         },
         async setEditable( value: boolean ): Promise<void> {
             const isEditable = this.editable;

--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -22,12 +22,8 @@
  */
 <template>
     <div
-        tabindex="1"
         class="layer-panel-wrapper"
         :class="{ collapsed }"
-        @click="handleFocus()"
-        @focus="handleFocus()"
-        @focusout="handleBlur()"
         @blur="handleBlur()"
     >
         <div class="component__header">
@@ -48,6 +44,7 @@
             <div
                 v-else
                 class="component__content form"
+                @click="handleFocus()"
             >
                 <div
                     v-if="reverseLayers.length"
@@ -66,6 +63,8 @@
                                     'layer--has-thumb': renderThumbnails,
                                 }"
                                 @contextmenu.stop.prevent="showContextMenu( $event, element )"
+                                @keyup.enter="handleFocus()"
+                                tabindex="0"
                             >
                                 <!-- thumbnail -->
                                 <div
@@ -97,7 +96,7 @@
                                         'layer--selected': isSelectedLayer( element ),
                                     }"
                                     @dblclick="handleLayerDoubleClick( element )"
-                                    @click.stop="handleLayerClick( element, $event )"
+                                    @click="handleLayerClick( element, $event )"
                                 >{{ element.name }}</span>
                                 <div class="layer__actions">
                                     <!-- optional layer mask -->
@@ -108,26 +107,26 @@
                                         :class="{
                                             'layer__actions-button--highlight': element.maskSelected
                                         }"
-                                        @click.stop="handleLayerMaskClick( element )"
+                                        @click="handleLayerMaskClick( element )"
                                     ><img src="@/assets-inline/images/icon-mask.svg" /></button>
                                     <button
                                         v-tooltip="$t('toggleVisibility')"
                                         type="button"
                                         class="layer__actions-button button--ghost"
-                                        @click.stop="handleToggleLayerVisibility( element.index )"
+                                        @click="handleToggleLayerVisibility( element.index )"
                                         :class="{ 'layer__actions-button--disabled': !element.visible }"
                                     ><img src="@/assets-inline/images/icon-eye.svg" /></button>
                                     <button
                                         v-tooltip="$t('effectsAndFilters')"
                                         type="button"
                                         class="layer__actions-button button--ghost"
-                                        @click.stop="handleEffectsClick( element.index )"
+                                        @click="handleEffectsClick( element.index )"
                                     ><img src="@/assets-inline/images/icon-settings.svg" /></button>
                                     <button
                                         v-tooltip="$t( element.mask ? 'deleteMask' : 'deleteLayer' )"
                                         type="button"
                                         class="layer__actions-button button--ghost"
-                                        @click.stop="handleRemoveClick( element.index )"
+                                        @click="handleRemoveClick( element.index )"
                                         :class="{ 'layer__actions-button--disabled': !canDelete }"
                                     ><img src="@/assets-inline/images/icon-trashcan.svg" /></button>
                                 </div>
@@ -147,14 +146,14 @@
                     type="button"
                     class="button button--small"
                     :disabled="!activeDocument"
-                    @click.stop="requestLayerAdd()"
+                    @click="requestLayerAdd()"
                 ></button>
                 <button
                     v-t="'addMask'"
                     type="button"
                     class="button button--small"
                     :disabled="!activeLayer || currentLayerHasMask"
-                    @click.stop="requestMaskAdd()"
+                    @click="requestMaskAdd()"
                 ></button>
             </div>
             <context-menu
@@ -278,6 +277,9 @@ export default {
         },
     },
     watch: {
+        activeTool(): void {
+            this.handleBlur();
+        },
         layers( _value: Layer[] ): void {
             this.resetSelectedLayers();
         },
@@ -302,7 +304,6 @@ export default {
             "removeLayer",
             "setActiveLayerIndex",
             "setActiveLayerMask",
-            "setActiveTool",
             "setOpenedPanel",
             "openDialog",
         ]),
@@ -392,6 +393,7 @@ export default {
         },
         handleBlur(): void {
             KeyboardService.setListener( null );
+            this.resetSelectedLayers();
         },
         handleKeyboard( type: string, keyCode: number, event: KeyboardEvent ): boolean {
             if ( type !== "down" ) {
@@ -455,6 +457,9 @@ export default {
                         this.resetSelectedLayers();
                     }
                     this.setActiveLayerIndex( nextDown );
+                    break;
+                case 37: // left
+                case 39: // right
                     break;
                 case 67: // C
                     if ( !KeyboardService.hasOption( event )) {

--- a/src/components/menus/header-menu/header-menu.vue
+++ b/src/components/menus/header-menu/header-menu.vue
@@ -34,7 +34,7 @@
         />
         <ul class="menu-list">
             <!-- file menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'file'" class="title" @click.prevent="openSubMenu('file')"></a>
                 <ul class="submenu"
                     :class="{ 'submenu--opened': activeSubMenu === 'file' }"
@@ -114,7 +114,7 @@
                 </ul>
             </li>
             <!-- edit menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'edit'" class="title" @click.prevent="openSubMenu('edit')"></a>
                 <ul class="submenu"
                     :class="{ 'submenu--opened': activeSubMenu === 'edit' }"
@@ -191,7 +191,7 @@
                 </ul>
             </li>
             <!-- document menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'document'" class="title" @click.prevent="openSubMenu('document')"></a>
                 <ul class="submenu"
                     :class="{ 'submenu--opened': activeSubMenu === 'document' }"
@@ -240,7 +240,7 @@
                 </ul>
             </li>
             <!-- layer menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'layer'" class="title" @click.prevent="openSubMenu('layer')"></a>
                 <layer-menu
                     :opened="activeSubMenu === 'layer'"
@@ -248,7 +248,7 @@
                 />
             </li>
             <!-- selection menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'selection'" class="title" @click.prevent="openSubMenu('selection')"></a>
                 <ul class="submenu"
                     :class="{ 'submenu--opened': activeSubMenu === 'selection' }"
@@ -298,7 +298,7 @@
                 </ul>
             </li>
             <!-- preferences -->
-            <li>
+            <li tabindex="0">
                 <a
                     v-t="'preferences'"
                     class="title"
@@ -306,7 +306,7 @@
                 ></a>
             </li>
             <!-- view menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'view'" class="title" @click.prevent="openSubMenu('view')"></a>
                 <ul class="submenu"
                     :class="{ 'submenu--opened': activeSubMenu === 'view' }"
@@ -349,7 +349,7 @@
                 </ul>
             </li>
             <!-- window menu -->
-            <li>
+            <li tabindex="0">
                 <a v-t="'window'" class="title" @click.prevent="openSubMenu('window')"></a>
                 <ul class="submenu"
                     :class="{ 'submenu--opened': activeSubMenu === 'window' }"

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -52,6 +52,8 @@ export default {
         ]),
     },
     mounted(): void {
+        this.focusedElement = document.activeElement;
+
         focus( this.$refs.content );
         this.escListener = ({ key }: KeyboardEvent ) => {
             if ( key === "Escape" ) {
@@ -62,6 +64,10 @@ export default {
     },
     unmounted(): void {
         window.removeEventListener( "keyup", this.escListener );
+
+        if ( this.focusedElement ) {
+            focus( this.focusedElement ); // restore focus on last interacted element
+        }
     },
 };
 </script>

--- a/src/services/keyboard-service.ts
+++ b/src/services/keyboard-service.ts
@@ -42,7 +42,7 @@ import { getCanvasInstance } from "@/services/canvas-service";
 import type { BitMapperyState } from "@/store";
 import { supportsFullscreen, toggleFullscreen } from "@/utils/environment-util";
 
-type ListenerRef = ( type: "up" | "down", keyCode: number, event: KeyboardEvent ) => void;
+export type ListenerRef = ( type: "up" | "down", keyCode: number, event: KeyboardEvent ) => boolean;
 
 let store: Store<BitMapperyState>;
 let state: BitMapperyState;
@@ -50,7 +50,7 @@ let getters: any;
 let commit: Commit;
 let dispatch: Dispatch;
 let listener: ListenerRef;
-let suspended = false, blockDefaults = true, optionDown = false, altDown = false, shiftDown = false, listenerCapturesAll = true;
+let suspended = false, blockDefaults = true, optionDown = false, altDown = false, shiftDown = false;
 let lastKeyDown = 0;
 let lastKeyCode = -1;
 let isMovingObject = false;
@@ -103,12 +103,11 @@ const KeyboardService =
     },
     /**
      * attach a listener to receive updates whenever a key
-     * has been released. When captureAll is true the listener will capture all
-     * keyboard actions (meaning the internal handlers here are omitted)
+     * has been released. When the listener returns true, it indicates
+     * the event is handled and all subsequent handling in this service can be omitted
      */
-    setListener( listenerRef: ListenerRef, captureAll = true ): void {
+    setListener( listenerRef: ListenerRef ): void {
         listener = listenerRef;
-        listenerCapturesAll = captureAll;
     },
     /**
      * the KeyboardService can be suspended so it
@@ -156,10 +155,11 @@ function handleKeyDown( event: KeyboardEvent ): void {
         preventDefault( event );
     }
     if ( typeof listener === "function" ) {
-        listener( "down", keyCode, event );
+        const handled = listener( "down", keyCode, event );
 
-        if ( listenerCapturesAll && keyCode !== 90 ) {
-            return; // unless "Z" is pressed (for undo/redo actions, skip remaining handling functions)
+        if ( handled ) {
+            event.preventDefault();
+            return;
         }
     }
     const hasOption = KeyboardService.hasOption( event );

--- a/src/services/keyboard-service.ts
+++ b/src/services/keyboard-service.ts
@@ -180,16 +180,6 @@ function handleKeyDown( event: KeyboardEvent ): void {
             }
             break;
 
-        case 9: // tab
-            commit( "setToolboxOpened", !state.toolboxOpened );
-            if ( state.openedPanels.length > 0 ) {
-                commit( "closeOpenedPanels" );
-            } else {
-                ALL_PANELS.forEach( panel => commit( "setOpenedPanel", panel ));
-            }
-            event.preventDefault();
-            break;
-
         case 17: // Ctrl
             optionDown = true;
             // prevent context menu from opening in this mode
@@ -207,7 +197,17 @@ function handleKeyDown( event: KeyboardEvent ): void {
             break;
 
         case 32: // spacebar
-            commit( "setPanMode", true );
+            if ( altDown ) {
+                commit( "setToolboxOpened", !state.toolboxOpened );
+                if ( state.openedPanels.length > 0 ) {
+                    commit( "closeOpenedPanels" );
+                } else {
+                    ALL_PANELS.forEach( panel => commit( "setOpenedPanel", panel ));
+                }
+                preventDefault( event );
+            } else {
+                commit( "setPanMode", true );
+            }
             break;
 
         case 38: // up
@@ -500,11 +500,11 @@ function handleKeyUp( event: KeyboardEvent ): void {
                 commit( "setPanMode", false );
             }
             break;
-        case 38:
-        case 40:
-        case 39:
-        case 37:
-            if ( MOVABLE_TOOL_TYPES.includes( getters.activeTool )) {
+        case 38: // up
+        case 40: // down
+        case 37: // left
+        case 39: // right
+            if ( MOVABLE_TOOL_TYPES.includes( getters.activeTool ) && getters.activeLayer ) {
                 stopLayerDrag( store, getters.activeLayer );
                 isMovingObject = false;
             }

--- a/src/services/keyboard-service.ts
+++ b/src/services/keyboard-service.ts
@@ -158,8 +158,7 @@ function handleKeyDown( event: KeyboardEvent ): void {
         const handled = listener( "down", keyCode, event );
 
         if ( handled ) {
-            event.preventDefault();
-            return;
+            return preventDefault( event );
         }
     }
     const hasOption = KeyboardService.hasOption( event );


### PR DESCRIPTION
### Motivation

When the pan or drag tools are selected (or a selection is active) the keyboard shortcuts in the layer panel would not allow navigating the layers list.

When the layer panel is focused no outside keyboard shortcuts should be captured.