### PR TITLE
Allow reorder of timeline tiles using drag

### DIFF
--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -288,7 +288,7 @@ export default {
     },
     mounted(): void {
         subscribe( "layers", ( layerId: string, data: string ) => {
-            const el = this.$refs[ `thumb_${layerId}` ];
+            const el = this.$refs[ `thumb_${layerId}` ] as HTMLImageElement;
             if ( el ) {
                 el.setAttribute( "src", data );
             }

--- a/src/components/timeline-panel/timeline-panel.vue
+++ b/src/components/timeline-panel/timeline-panel.vue
@@ -138,7 +138,7 @@ export default {
         },
         timelineTiles: {
             get(): RelId[] {
-                return this.activeDocument.groups;
+                return this.activeDocument?.groups ?? [];
             },
             set( groups: RelId[] ) {
                 reorderTiles( this.$store, this.activeDocument, groups );
@@ -184,7 +184,7 @@ export default {
     mounted(): void {
         subscribeTile( SUBSCRIPTION_TOKEN, ( id: RelId, tile: Tile ) => {
             if ( !this.renderTile( id, tile )) {
-                this.renderTileDebounced( id, tile ); // draggable list not updated yet
+                this.renderTileDebounced( id, tile ); // draggable list likely still mounting (canvas tile not available yet)
             }
         });
         // to manage on-the-fly updates of group tiles, we track changes to layer thumbnails
@@ -197,6 +197,7 @@ export default {
         });
     },
     beforeUnmount(): void {
+        clearTimeout( pendingTimeout );
         pending.clear();
         unsubscribeTile( SUBSCRIPTION_TOKEN );
         unsubscribeThumbnail( SUBSCRIPTION_TOKEN );

--- a/src/components/timeline-panel/timeline-panel.vue
+++ b/src/components/timeline-panel/timeline-panel.vue
@@ -39,21 +39,27 @@
             ></button>
         </div>
         <div class="component__content">
-            <div class="timeline__tiles">
-                <canvas
-                    v-for="tile in activeDocument.groups"
-                    :ref="`thumb_${tile}`"
-                    class="timeline__tile"
-                    @click.stop.prevent="setActiveGroup( tile )"
-                    @contextmenu.stop.prevent="showContextMenu( $event, tile )"
-                    :class="{
-                        'timeline__tile--active': tile === activeGroup
-                    }"
-                    :width="thumbSize.width"
-                    :height="thumbSize.height"
-                >
-                </canvas>
-            </div>
+            <draggable
+                v-model="timelineTiles"
+                @change="handleTileDrag"
+                class="timeline__tiles"
+                itemKey="id"
+            >
+                <template #item="{element}">
+                    <canvas
+                        :ref="`thumb_${element}`"
+                        class="timeline__tile"
+                        @click.stop.prevent="setActiveGroup( element )"
+                        @contextmenu.stop.prevent="showContextMenu( $event, element )"
+                        :class="{
+                            'timeline__tile--active': element === activeGroup
+                        }"
+                        :width="thumbSize.width"
+                        :height="thumbSize.height"
+                    >
+                    </canvas>
+                </template>
+            </draggable>
         </div>
         <context-menu
             v-if="contextMenu.show"
@@ -93,6 +99,7 @@ import {
     createGroupTile, flushTileCache, subscribe as subscribeTile, THUMB_HEIGHT, type Tile, unsubscribe as unsubscribeTile
 } from "@/rendering/cache/tile-cache";
 import { subscribe as subscribeThumbnail, unsubscribe as unsubscribeThumbnail } from "@/rendering/cache/thumbnail-cache";
+import { reorderTiles } from "@/store/actions/tile-reorder";
 import { addTile } from "@/store/actions/tile-add";
 import { cloneTile } from "@/store/actions/tile-clone";
 import { deleteTile } from "@/store/actions/tile-delete";
@@ -102,11 +109,14 @@ import { getAllTileGroupsInDocument, getIndexOfFirstLayerInTileGroup, getTileByL
 import messages from "./messages.json";
 
 const SUBSCRIPTION_TOKEN = "timeline"; // safe to declare outside of component as only one instance is used
+const pending: Map<RelId, Tile> = new Map();
+let pendingTimeout: ReturnType<typeof setTimeout>;
 
 export default {
     i18n: { messages },
     components: {
         ContextMenu : defineAsyncComponent({ loader: () => import( "@/components/menus/context-menu/context-menu.vue" ) }),
+        Draggable : defineAsyncComponent({ loader: () => import( "vuedraggable" ) }),
         ToggleButton,
     },
     data: () => ({
@@ -125,6 +135,14 @@ export default {
         ]),
         thumbSize(): Size {
             return scaleToFixedHeight( this.activeDocument?.width, this.activeDocument?.height, THUMB_HEIGHT * getPixelRatio());
+        },
+        timelineTiles: {
+            get(): RelId[] {
+                return this.activeDocument.groups;
+            },
+            set( groups: RelId[] ) {
+                reorderTiles( this.$store, this.activeDocument, groups );
+            },
         },
     },
     watch: {
@@ -165,11 +183,8 @@ export default {
     },
     mounted(): void {
         subscribeTile( SUBSCRIPTION_TOKEN, ( id: RelId, tile: Tile ) => {
-            const el = this.$refs[ `thumb_${id}` ] as HTMLCanvasElement[];
-            if ( el ) {
-                el[ 0 ].width = tile.thumb.width;
-                el[ 0 ].height = tile.thumb.height;
-                el[ 0 ].getContext( "2d" )!.drawImage( tile.thumb, 0, 0 );
+            if ( !this.renderTile( id, tile )) {
+                this.renderTileDebounced( id, tile ); // draggable list not updated yet
             }
         });
         // to manage on-the-fly updates of group tiles, we track changes to layer thumbnails
@@ -182,6 +197,7 @@ export default {
         });
     },
     beforeUnmount(): void {
+        pending.clear();
         unsubscribeTile( SUBSCRIPTION_TOKEN );
         unsubscribeThumbnail( SUBSCRIPTION_TOKEN );
         flushTileCache();
@@ -212,6 +228,31 @@ export default {
         },
         handlePlay(): void {
             this.openModal( ANIMATION_PREVIEW );
+        },
+        handleTileDrag( dragEvent: { moved: { element: RelId, newIndex: number, oldIndex: number }}): void {
+            this.setActiveGroup( dragEvent.moved.element );
+        },
+        renderTile( id: RelId, tile: Tile ): boolean {
+            const el = this.$refs[ `thumb_${id}` ] as HTMLCanvasElement;
+            if ( !el ) {
+                return false;
+            }
+            el.width = tile.thumb.width;
+            el.height = tile.thumb.height;
+            el.getContext( "2d" )!.drawImage( tile.thumb, 0, 0 );
+
+            return true;
+        },
+        renderTileDebounced( id: RelId, tile: Tile ): void {
+            pending.set( id, tile );
+
+            clearTimeout( pendingTimeout );
+            pendingTimeout = setTimeout(() => {
+                for ( const [ id, tile ] of pending.entries() ) {
+                    this.renderTile( id, tile );
+                }
+                pending.clear();
+            }, 10 );
         },
         async cacheTiles(): Promise<void> {
             const groupIds = getAllTileGroupsInDocument( this.activeDocument );

--- a/src/components/timeline-panel/timeline-panel.vue
+++ b/src/components/timeline-panel/timeline-panel.vue
@@ -99,10 +99,10 @@ import {
     createGroupTile, flushTileCache, subscribe as subscribeTile, THUMB_HEIGHT, type Tile, unsubscribe as unsubscribeTile
 } from "@/rendering/cache/tile-cache";
 import { subscribe as subscribeThumbnail, unsubscribe as unsubscribeThumbnail } from "@/rendering/cache/thumbnail-cache";
-import { reorderTiles } from "@/store/actions/tile-reorder";
 import { addTile } from "@/store/actions/tile-add";
 import { cloneTile } from "@/store/actions/tile-clone";
 import { deleteTile } from "@/store/actions/tile-delete";
+import { reorderTiles } from "@/store/actions/tile-reorder";
 import { getPixelRatio } from "@/utils/canvas-util";
 import { SmartExecutor } from "@/utils/debounce-util";
 import { getAllTileGroupsInDocument, getIndexOfFirstLayerInTileGroup, getTileByLayer } from "@/utils/timeline-util";

--- a/src/store/actions/tile-reorder.ts
+++ b/src/store/actions/tile-reorder.ts
@@ -1,0 +1,55 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Igor Zinken 2026 - https://www.igorski.nl
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import { type Store } from "vuex";
+import type { Document, RelId } from "@/definitions/document";
+import { enqueueState } from "@/factories/history-state-factory";
+import { rebuildAllThumbnails } from "@/rendering/cache/thumbnail-cache";
+import { rebuildAllTiles } from "@/rendering/cache/tile-cache";
+import { type BitMapperyState } from "@/store";
+
+/**
+ * relIds represents an ordered list
+ * we don't actually reorder the groups list but rather the order of the layers by their rel.id
+ */
+export const reorderTiles = ( store: Store<BitMapperyState>, activeDocument: Document, relIds: RelId[] ): void => {
+    const originalLayerOrder = activeDocument.layers.map( layer => layer.id );
+    const newLayerOrder = [ ...activeDocument.layers ].sort(( a, b ) => {
+        return relIds.indexOf( a.rel.id ) - relIds.indexOf( b.rel.id );
+    }).map( layer => layer.id );
+    
+    const commit = async (): Promise<void> => {
+        store.commit( "reorderLayers", { activeDocument, layerIds: newLayerOrder } );
+        await rebuildAllThumbnails( activeDocument );
+        await rebuildAllTiles( activeDocument );
+    };
+    commit();
+    
+    enqueueState( `reorderLayers_${relIds.join()}`, {
+        async undo(): Promise<void> {
+            store.commit( "reorderLayers", { activeDocument, layerIds: originalLayerOrder } );
+            await rebuildAllThumbnails( activeDocument );
+            await rebuildAllTiles( activeDocument );
+        },
+        redo: commit,
+    });
+};

--- a/tests/unit/store/actions/tile-reorder.spec.ts
+++ b/tests/unit/store/actions/tile-reorder.spec.ts
@@ -1,0 +1,138 @@
+import { type Store } from "vuex";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStore, flushPromises, mockZCanvas } from "../../mocks";
+
+mockZCanvas();
+
+import type { Document, Layer } from "@/definitions/document";
+import DocumentFactory from "@/factories/document-factory";
+import LayerFactory from "@/factories/layer-factory";
+import { type BitMapperyState } from "@/store";
+import { reorderTiles } from "@/store/actions/tile-reorder";
+
+const mockEnqueueState = vi.fn();
+vi.mock( "@/factories/history-state-factory", () => ({
+    enqueueState: ( ...args: any[] ) => mockEnqueueState( ...args ),
+}));
+
+const mockRebuildAllThumbnails = vi.fn();
+vi.mock( "@/rendering/cache/thumbnail-cache", () => ({
+    rebuildAllThumbnails: ( ...args: any[] ) => mockRebuildAllThumbnails( ...args ),
+}));
+
+const mockRebuildAllTiles = vi.fn();
+vi.mock( "@/rendering/cache/tile-cache", () => ({
+    rebuildAllTiles: ( ...args: any[] ) => mockRebuildAllTiles( ...args ),
+}));
+
+describe( "Tile reorder action", () => {
+    let store: Store<BitMapperyState>;
+    let activeDocument: Document;
+    
+    const tile1Layer1 = LayerFactory.create({ rel: { type: "tile", id: 0 }});
+    const tile1Layer2 = LayerFactory.create({ rel: { type: "tile", id: 0 }});
+
+    const tile2Layer1 = LayerFactory.create({ rel: { type: "tile", id: 1 }});
+    const tile2Layer2 = LayerFactory.create({ rel: { type: "tile", id: 1 }});
+
+    const tile3Layer1 = LayerFactory.create({ rel: { type: "tile", id: 2 }});
+
+    beforeEach(() => {
+        store = createStore();
+        store.getters.activeGroup = 1;
+
+        activeDocument = DocumentFactory.create({
+            width: 500,
+            height: 500,
+            layers: [
+                tile1Layer1, tile1Layer2,
+                tile2Layer1, tile2Layer2,
+                tile3Layer1,
+            ],
+        });
+        activeDocument.groups = [ 0, 1, 2 ];
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    describe( "when reordering tiles", () => {
+        it( "should reorder the layer indices", () => {
+            reorderTiles( store, activeDocument, [ 1, 0, 2 ]);
+
+            expect( store.commit ).toHaveBeenCalledWith( "reorderLayers", {
+                activeDocument,
+                layerIds: [
+                    tile2Layer1.id, tile2Layer2.id,
+                    tile1Layer1.id, tile1Layer2.id,
+                    tile3Layer1.id,
+                ],
+            });
+        });
+
+        it( "should rebuild all Layer thumbnails", async () => {
+            reorderTiles( store, activeDocument, [ 1, 0, 2 ]);
+
+            expect( mockRebuildAllThumbnails ).toHaveBeenCalledOnce();
+        });
+
+        it( "should rebuild all tiles", async () => {
+            reorderTiles( store, activeDocument, [ 1, 0, 2 ]);
+
+            await flushPromises();
+
+            expect( mockRebuildAllTiles ).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe( "when restoring tile reordering", () => {
+        it( "should restore the original Layer indices", async () => {
+            reorderTiles( store, activeDocument, [ 1, 0, 2 ]);
+
+            await flushPromises();
+
+            const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+            vi.resetAllMocks();
+
+            undo();
+
+            expect( store.commit ).toHaveBeenCalledWith( "reorderLayers", {
+                activeDocument,
+                layerIds: [
+                    tile1Layer1.id, tile1Layer2.id,
+                    tile2Layer1.id, tile2Layer2.id,
+                    tile3Layer1.id,
+                ],
+            });
+        });
+
+        it( "should rebuild all Layer thumbnails", async () => {
+            reorderTiles( store, activeDocument, [ 1, 0, 2 ]);
+
+            await flushPromises();
+
+            const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+            vi.resetAllMocks();
+
+            undo();
+
+            expect( mockRebuildAllThumbnails ).toHaveBeenCalledOnce();
+        });
+
+        it( "should rebuild all tiles", async () => {
+            reorderTiles( store, activeDocument, [ 1, 0, 2 ]);
+
+            await flushPromises();
+
+            const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+            vi.resetAllMocks();
+
+            undo();
+
+            await flushPromises();
+
+            expect( mockRebuildAllTiles ).toHaveBeenCalledOnce();
+        });
+    });
+});


### PR DESCRIPTION
### Motivation

Tiles in a timeline cannot be reordered after creation, which can be a little cumbersome.

Implement draggable tiles allowing the user to reorder tiles at any moment.