### PR TITLE
Address issue when merging and flattening Layers in a Timeline Document

### DIFF
--- a/src/components/menus/layer-menu/layer-menu.vue
+++ b/src/components/menus/layer-menu/layer-menu.vue
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Igor Zinken 2020-2025 - https://www.igorski.nl
+ * Igor Zinken 2020-2026 - https://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -70,7 +70,7 @@
             <button
                 v-t="'mergeDown'"
                 type="button"
-                :disabled="!activeLayer || activeLayerIndex === 0"
+                :disabled="!canMergeDown"
                 @click="requestMergeLayerDown()"
             ></button>
         </li>
@@ -78,7 +78,7 @@
             <button
                 v-t="'flattenImage'"
                 type="button"
-                :disabled="!activeLayer || activeDocument.layers.length < 2"
+                :disabled="!canFlatten"
                 @click="requestMergeLayerDown( true )"
             ></button>
         </li>
@@ -95,6 +95,7 @@ import { mergeLayerDown } from "@/store/actions/layer-merge-down";
 import { pasteLayerFilters } from "@/store/actions/layer-paste-filters";
 import { toggleLayerFilters } from "@/store/actions/layer-toggle-filters";
 import { hasTransform } from "@/utils/layer-util";
+import { getIndexOfFirstLayerInTileGroup, getLayersByTile } from "@/utils/timeline-util";
 
 import messages from "./messages.json";
 
@@ -109,6 +110,7 @@ export default {
     computed: {
         ...mapGetters([
             "activeDocument",
+            "activeGroup",
             "activeLayer",
             "activeLayerIndex",
             "clonedFilters",
@@ -118,6 +120,27 @@ export default {
         },
         activeLayerHasFiltersEnabled(): boolean {
             return this.activeLayer?.filters?.enabled;
+        },
+        canMergeDown(): boolean {
+            if ( !this.activeLayer ) {
+                return false;
+            }
+            if ( this.hasTimeline ) {
+                return this.activeLayerIndex > getIndexOfFirstLayerInTileGroup( this.activeDocument, this.activeGroup );
+            }
+            return this.activeLayerIndex > 0;
+        },
+        canFlatten(): boolean {
+            if ( !this.activeLayer ) {
+                return false;
+            }
+            if ( this.hasTimeline ) {
+                return getLayersByTile( this.activeDocument, this.activeGroup ).length >= 2;
+            }
+            return this.activeDocument.layers.length >= 2;
+        },
+        hasTimeline(): boolean {
+            return this.activeDocument?.type === "timeline";
         },
     },
     methods: {

--- a/src/store/actions/layer-merge-down.ts
+++ b/src/store/actions/layer-merge-down.ts
@@ -53,7 +53,7 @@ export const mergeLayerDown = async (
         layers = [ activeDocument.layers[ layerIndices[ 0 ]], activeLayer ];
     }
     const { width, height } = activeDocument;
-    const mergeIndex = allLayers && !hasTimeline ? 0 : layerIndices[ 0 ];
+    const mergeIndex = layerIndices[ 0 ];
     const newLayer = LayerFactory.create({
         name,
         source: await resizeImage( createSyncSnapshot( activeDocument, layerIndices ), width, height ),
@@ -61,7 +61,7 @@ export const mergeLayerDown = async (
         height,
         rel: hasTimeline ? {
             type: "tile",
-            id: store.getters.activeGroup,
+            id: activeGroup,
         } : undefined,
     });
     

--- a/src/store/actions/layer-merge-down.ts
+++ b/src/store/actions/layer-merge-down.ts
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Igor Zinken 2020-2025 - https://www.igorski.nl
+ * Igor Zinken 2020-2026 - https://www.igorski.nl
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -27,30 +27,44 @@ import LayerFactory from "@/factories/layer-factory";
 import type { BitMapperyState } from "@/store";
 import { resizeImage } from "@/utils/canvas-util";
 import { createSyncSnapshot } from "@/utils/document-util";
+import { getLayersByTile } from "@/utils/timeline-util";
 
 export const mergeLayerDown = async (
     store: Store<BitMapperyState>, activeDocument: Document, activeLayer: Layer, activeLayerIndex: number, name: string, allLayers = false,
 ): Promise<void> => {
+    const hasTimeline = activeDocument.type === "timeline";
+    const { activeGroup } = store.getters;
+
     let layers: Layer[] = [];
     let layerIndices: number[] = [];
     // collect the layers in ascending order
     if ( allLayers ) {
-        activeDocument.layers.forEach(( layer, index ) => {
-            layers.push( layer );
-            layerIndices.push( index );
-        });
+        if ( hasTimeline ) {
+            layers = getLayersByTile( activeDocument, activeGroup );
+            layerIndices = layers.map( layer => activeDocument.layers.findIndex( compare => compare.id === layer.id  ));
+        } else {
+            activeDocument.layers.forEach(( layer, index ) => {
+                layers.push( layer );
+                layerIndices.push( index );
+            });
+        }
     } else {
         layerIndices = [ activeLayerIndex - 1, activeLayerIndex ];
         layers = [ activeDocument.layers[ layerIndices[ 0 ]], activeLayer ];
     }
     const { width, height } = activeDocument;
-    const mergeIndex = allLayers ? 0 : layerIndices[ 0 ];
+    const mergeIndex = allLayers && !hasTimeline ? 0 : layerIndices[ 0 ];
     const newLayer = LayerFactory.create({
         name,
         source: await resizeImage( createSyncSnapshot( activeDocument, layerIndices ), width, height ),
         width,
         height,
+        rel: hasTimeline ? {
+            type: "tile",
+            id: store.getters.activeGroup,
+        } : undefined,
     });
+    
     const commit = (): void => {
         let i = layerIndices.length;
         while ( i-- ) {

--- a/tests/unit/store/actions/layer-merge-down.spec.ts
+++ b/tests/unit/store/actions/layer-merge-down.spec.ts
@@ -194,6 +194,18 @@ describe( "layer merge action", () => {
                 expect( layer.name ).toEqual( "foo" );
             });
 
+            it( "should insert a new Layer with the appropriate Tile group relation", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                // @ts-expect-error TS2339 Property 'mock' does not exist on type 'Commit'.
+                const { layer } = store.commit.mock.calls[ 2 ][ 1 ];
+
+                expect( layer.rel ).toEqual({
+                    type: "tile",
+                    id: store.getters.activeGroup,
+                });
+            });
+
             it( "should store the action in state history", async () => {
                 await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
         

--- a/tests/unit/store/actions/layer-merge-down.spec.ts
+++ b/tests/unit/store/actions/layer-merge-down.spec.ts
@@ -1,0 +1,278 @@
+import { type Store } from "vuex";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockCanvasElement, createStore, mockZCanvas } from "../../mocks";
+
+mockZCanvas();
+
+import DocumentFactory from "@/factories/document-factory";
+import LayerFactory from "@/factories/layer-factory";
+import { type BitMapperyState } from "@/store";
+import { mergeLayerDown } from "@/store/actions/layer-merge-down";
+
+const mockEnqueueState = vi.fn();
+vi.mock( "@/factories/history-state-factory", () => ({
+    enqueueState: ( ...args: any[] ) => mockEnqueueState( ...args ),
+}));
+
+vi.mock( "@/utils/canvas-util", async ( importOriginal ) => {
+    return {
+        ...await importOriginal(),
+        resizeImage: () => Promise.resolve( createMockCanvasElement()),
+    };
+});
+
+vi.mock( "@/utils/document-util", () => ({
+    createSyncSnapshot: () => createMockCanvasElement(),
+}));
+
+describe( "layer merge action", () => {
+    let store: Store<BitMapperyState>;
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    describe( "for a default Document type", () => {
+        const activeDocument = DocumentFactory.create({
+            layers: [
+                LayerFactory.create(),
+                LayerFactory.create(),
+                LayerFactory.create(),
+            ],
+        });
+        const activeLayerIndex = 2;
+        const activeLayer = activeDocument.layers[ activeLayerIndex ];
+
+        beforeEach(() => {
+            store = createStore();
+        });
+
+        describe( "when merging two Layers", () => {
+            it( "should remove the active Layer and the Layer below it", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", activeLayerIndex );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "removeLayer", activeLayerIndex - 1 );
+            });
+
+            it( "should insert a new Layer with the provided name", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "insertLayerAtIndex", {
+                    index: activeLayerIndex - 1,
+                    layer: expect.any( Object ),
+                });
+
+                // @ts-expect-error TS2339 Property 'mock' does not exist on type 'Commit'.
+                const { layer } = store.commit.mock.calls[ 2 ][ 1 ];
+
+                expect( layer.name ).toEqual( "foo" );
+            });
+
+            it( "should store the action in state history", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+        
+                expect( mockEnqueueState ).toHaveBeenCalledWith( 
+                    expect.any( String ), {
+                        undo: expect.any( Function ),
+                        redo: expect.any( Function )
+                    }
+                );
+            });
+
+            it( "should be able to undo the merge and restore the original Layers", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+                vi.resetAllMocks();
+
+                undo();
+
+                expect( store.commit ).toHaveBeenCalledTimes( 3 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", activeLayerIndex - 1 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "insertLayerAtIndex", {
+                    index: activeLayerIndex - 1,
+                    layer: activeDocument.layers[ activeLayerIndex - 1 ]
+                });
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "insertLayerAtIndex", {
+                    index: activeLayerIndex,
+                    layer: activeDocument.layers[ activeLayerIndex ]
+                });
+            });
+        });
+
+        describe( "when merging all Layers in the Document", () => {
+            it( "should remove all Layers", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", true );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", 2 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "removeLayer", 1 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "removeLayer", 0 );
+            });
+
+            it( "should insert a new Layer with the provided name", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", true );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 4, "insertLayerAtIndex", {
+                    index: 0,
+                    layer: expect.any( Object ),
+                });
+
+                // @ts-expect-error TS2339 Property 'mock' does not exist on type 'Commit'.
+                const { layer } = store.commit.mock.calls[ 3 ][ 1 ];
+
+                expect( layer.name ).toEqual( "foo" );
+            });
+
+            it( "should be able to undo the merge and restore the original Layers", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", true );
+
+                const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+                vi.resetAllMocks();
+
+                undo();
+
+                expect( store.commit ).toHaveBeenCalledTimes( 4 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", 0 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "insertLayerAtIndex", {
+                    index: 0,
+                    layer: activeDocument.layers[ 0 ]
+                });
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "insertLayerAtIndex", {
+                    index: 1,
+                    layer: activeDocument.layers[ 1 ]
+                });
+                expect( store.commit ).toHaveBeenNthCalledWith( 4, "insertLayerAtIndex", {
+                    index: 2,
+                    layer: activeDocument.layers[ 2 ]
+                });
+            });
+        });
+    });
+
+    describe( "for a timeline Document type", () => {
+         const activeDocument = DocumentFactory.create({
+            type: "timeline",
+            layers: [
+                LayerFactory.create({ rel: { type: "tile", id: 0 }}),
+                LayerFactory.create({ rel: { type: "tile", id: 0 }}),
+
+                LayerFactory.create({ rel: { type: "tile", id: 1 }}),
+                LayerFactory.create({ rel: { type: "tile", id: 1 }}),
+                LayerFactory.create({ rel: { type: "tile", id: 1 }}),
+
+                LayerFactory.create({ rel: { type: "tile", id: 2 }}),
+            ],
+        });
+        const activeLayerIndex = 3;
+        const activeLayer = activeDocument.layers[ activeLayerIndex ];
+
+        beforeEach(() => {
+            store = createStore();
+            store.getters.activeGroup = 1;
+        });
+
+        describe( "when merging two Layers in a tile group", () => {
+            it( "should remove the active Layer and the Layer below it", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", activeLayerIndex );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "removeLayer", activeLayerIndex - 1 );
+            });
+
+            it( "should insert a new Layer with the provided name", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "insertLayerAtIndex", {
+                    index: activeLayerIndex - 1,
+                    layer: expect.any( Object ),
+                });
+
+                // @ts-expect-error TS2339 Property 'mock' does not exist on type 'Commit'.
+                const { layer } = store.commit.mock.calls[ 2 ][ 1 ];
+
+                expect( layer.name ).toEqual( "foo" );
+            });
+
+            it( "should store the action in state history", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+        
+                expect( mockEnqueueState ).toHaveBeenCalledWith( 
+                    expect.any( String ), {
+                        undo: expect.any( Function ),
+                        redo: expect.any( Function )
+                    }
+                );
+            });
+
+            it( "should be able to undo the merge and restore the original Layers", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", false );
+
+                const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+                vi.resetAllMocks();
+
+                undo();
+
+                expect( store.commit ).toHaveBeenCalledTimes( 3 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", activeLayerIndex - 1 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "insertLayerAtIndex", {
+                    index: activeLayerIndex - 1,
+                    layer: activeDocument.layers[ activeLayerIndex - 1 ]
+                });
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "insertLayerAtIndex", {
+                    index: activeLayerIndex,
+                    layer: activeDocument.layers[ activeLayerIndex ]
+                });
+            });
+        });
+
+        describe( "when merging all Layers in a tile group", () => {
+            it( "should remove all Layers for that group", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", true );
+
+                expect( store.commit ).toHaveBeenCalledTimes( 4 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", 4 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "removeLayer", 3 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "removeLayer", 2 );
+            });
+
+            it( "should insert a new Layer with the provided name", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", true );
+
+                expect( store.commit ).toHaveBeenNthCalledWith( 4, "insertLayerAtIndex", {
+                    index: 2,
+                    layer: expect.any( Object ),
+                });
+
+                // @ts-expect-error TS2339 Property 'mock' does not exist on type 'Commit'.
+                const { layer } = store.commit.mock.calls[ 3 ][ 1 ];
+
+                expect( layer.name ).toEqual( "foo" );
+            });
+
+            it( "should be able to undo the merge and restore the original Layers", async () => {
+                await mergeLayerDown( store, activeDocument, activeLayer, activeLayerIndex, "foo", true );
+
+                const { undo } = mockEnqueueState.mock.calls[ 0 ][ 1 ];
+                vi.resetAllMocks();
+
+                undo();
+
+                expect( store.commit ).toHaveBeenCalledTimes( 4 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 1, "removeLayer", 2 );
+                expect( store.commit ).toHaveBeenNthCalledWith( 2, "insertLayerAtIndex", {
+                    index: 2,
+                    layer: activeDocument.layers[ 2 ]
+                });
+                expect( store.commit ).toHaveBeenNthCalledWith( 3, "insertLayerAtIndex", {
+                    index: 3,
+                    layer: activeDocument.layers[ 3 ]
+                });
+                expect( store.commit ).toHaveBeenNthCalledWith( 4, "insertLayerAtIndex", {
+                    index: 4,
+                    layer: activeDocument.layers[ 4 ]
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Motivation

When merging a layer down / flattening the layers in a Timeline Document, it is more logical if this is done for the currently active Tile group, instead of the whole Document.