### PR TITLE
Upgrade Node.js base image to version 24-alpine

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 # Written by Ange Cesari
 # Use official Node.js based on Alpine
-FROM node:20-alpine
+FROM node:24-alpine
 
 # Install Yarn
 RUN apk add --no-cache yarn

--- a/dockerfile
+++ b/dockerfile
@@ -2,9 +2,6 @@
 # Use official Node.js based on Alpine
 FROM node:24-alpine
 
-# Install Yarn
-RUN apk add --no-cache yarn
-
 # Create dir for application
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Current dockerfile fails to build. Updating Node.js base image from version 20 to 24 brings it to the current LTS and builds successfully for me.

<!--
Thank you for contributing to this project. You must fill out the information below before the pull request will be reviewed. By
explaining why you're making a change and what changes you've made, your pull request can be triaged for review.
-->

### Motivation

Current dockerfile fails to build.

### Check off the following:

- [ x ] The changes in this PR meet the [contributor guidelines](https://github.com/igorski/.github/blob/main/CONTRIBUTING.md)
- [ x ] All build checks are passing
